### PR TITLE
Move the configuration of test ports and database name into a properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Either clone the repository or download and extract a snapshot
 
 Edit `server/gradle.properties` to point to your mongodb and liberty installation directories.
 
+Have a look at `test-utils/src/main/resources/config.properties` and check that you are happy with the
+specified test ports
+
 Launch gradle to build the code, run the tests and produce the distribution archives.
 
     gradle build dist

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ apply plugin: 'eclipse'
 
 boolean haveAnyTestsFailed = false;
 
+loadProperties("${rootProject.rootDir}/test-utils/src/main/resources/config.properties");
+
+
 // General configuration for all projects
 // Set up support for fatTests which rely on a running test server
 subprojects {
@@ -166,4 +169,21 @@ task afterEclipseImport << {
     XmlNodePrinter printer = new XmlNodePrinter(new PrintWriter(file('.project')))
     printer.preserveWhitespace = true
     printer.print(node)
+}
+
+// Function to load configuration properties from a normal
+// java properties file. This seems to be necessary to allow
+// properties that are visible to both gradle script and java
+// testcases
+void loadProperties(String fileName) {
+    Properties properties = new Properties();
+    File propertiesFile = new File(fileName);
+    propertiesFile.withInputStream {
+        properties.load(it);
+    }
+        
+    properties.propertyNames().each {
+        project.ext.set(it, properties.get(it));
+    }
+    
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.+'
     testCompile group:'org.apache.httpcomponents', name:'httpclient', version:'4.3.+'
     testCompile group:'org.apache.httpcomponents', name:'httpmime', version:'4.3.+'
+    testCompile project(':test-utils')
     
     antTasks group:'net.wasdev.wlp.ant', name:'wlp-anttasks', version:'1.0'
 }
@@ -131,6 +132,7 @@ task createTestUsrDir (type: Copy) {
         into "servers/${testServerName}"
         rename 'testServer\\.xml', 'server.xml'
         filter(ReplaceTokens, tokens:['HTTP_PORT':testLibertyPort,
+                                      'TEST_DB_NAME':testDbName,
                                       'MONGO_PORT':testMongoPort])
     }
 }

--- a/server/config/testServer.xml
+++ b/server/config/testServer.xml
@@ -58,7 +58,7 @@ limitations under the License.
         <ports>@MONGO_PORT@</ports>
     </mongo>
     
-    <mongoDB databaseName="larsDB" jndiName="mongo/larsDB" mongoRef="mongo"/>
+    <mongoDB databaseName="@TEST_DB_NAME@" jndiName="mongo/larsDB" mongoRef="mongo"/>
 
     <webApplication id="com.ibm.ws.lars.rest" location="larsServer.war" name="com.ibm.ws.lars.rest" contextRoot="/">
          <classloader commonLibraryRef="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party"/>

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -8,14 +8,4 @@ libertyRoot=/liberty/install/directory/wlp
 # This is needed to run the fat tests
 mongodExecutable=/mongodb/install/directory/bin/mongod
 
-# Test Ports
-# ----------
-# Running tests involves starting up instances of mongod and liberty
-# Here you may set the ports that should be used by mongod and liberty during a test run
-# By default they're set differently to the standard ports so that they won't clash with
-# another mongod or liberty running on the same machine
 
-# The port that mongod should use for test runs
-testMongoPort=27020
-# The port that liberty should use for test runs
-testLibertyPort=9085

--- a/server/src/fat/java/com/ibm/ws/lars/rest/PermissionTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/PermissionTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized.Parameters;
 import com.ibm.ws.lars.rest.model.Asset;
 import com.ibm.ws.lars.rest.model.AssetList;
 import com.ibm.ws.lars.rest.model.Attachment;
+import com.ibm.ws.lars.testutils.FatUtils;
 
 /**
  * Test that security permissions work correctly.
@@ -53,14 +54,14 @@ public class PermissionTest {
     /**
      * URL for the test instance where read operations are restricted to users with the User role.
      */
-    private static final String RESTRICTED_URL = "http://localhost:9085/ma/v1";
+    private static final String RESTRICTED_URL = RepositoryContext.DEFAULT_URL;
 
     /**
      * URL for the test instance where read operations are unrestricted.
      * <p>
      * Write operations are still restricted to users with the Admin role.
      */
-    private static final String UNRESTRICTED_URL = "http://localhost:9085/unrestricted/ma/v1";
+    private static final String UNRESTRICTED_URL = "http://localhost:" + FatUtils.LIBERTY_PORT + "/unrestricted" + FatUtils.LARS_APPLICATION_ROOT;
 
     /**
      * The available roles that we expect test users to be mapped to by the test server

--- a/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
@@ -65,6 +65,7 @@ import com.ibm.ws.lars.rest.model.Asset;
 import com.ibm.ws.lars.rest.model.AssetList;
 import com.ibm.ws.lars.rest.model.Attachment;
 import com.ibm.ws.lars.rest.model.AttachmentList;
+import com.ibm.ws.lars.testutils.FatUtils;
 
 /**
  * Context used by testcases to perform HTTP operations against one LARS server. Tests should use
@@ -92,7 +93,7 @@ public class RepositoryContext extends ExternalResource {
     private HttpHost targetHost;
     private HttpClientContext context;
 
-    private static final String DEFAULT_URL = "http://localhost:9085/ma/v1";
+    public static final String DEFAULT_URL = "http://localhost:" + FatUtils.LIBERTY_PORT + FatUtils.LARS_APPLICATION_ROOT;
 
     /**
      * Special constant that can be passed as an expected response code to indicate that either a

--- a/test-utils/src/main/java/com/ibm/ws/lars/testutils/FatUtils.java
+++ b/test-utils/src/main/java/com/ibm/ws/lars/testutils/FatUtils.java
@@ -16,9 +16,18 @@
 
 package com.ibm.ws.lars.testutils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class FatUtils {
 
     public static final String SCRIPT;
+
+    public static final String DB_PORT;
+    public static final String LIBERTY_PORT;
+    public static final String TEST_DB_NAME;
+    public static final String LARS_APPLICATION_ROOT;
 
     static {
         if (System.getProperty("os.name").startsWith("Windows")) {
@@ -26,13 +35,26 @@ public class FatUtils {
         } else {
             SCRIPT = "client/bin/larsClient";
         }
+
+        Properties defaultConfig = new Properties();
+        InputStream propsStream = FatUtils.class.getClassLoader().getResourceAsStream("config.properties");
+        try {
+            defaultConfig.load(propsStream);
+        } catch (IOException e) {
+            // Can't recover from this
+            throw new RuntimeException("Unable to find config.properties file for database/server configuration");
+        }
+
+        DB_PORT = defaultConfig.getProperty("testMongoPort");
+        LIBERTY_PORT = defaultConfig.getProperty("testLibertyPort");
+        TEST_DB_NAME = defaultConfig.getProperty("testDbName");
+        LARS_APPLICATION_ROOT = defaultConfig.getProperty("larsApplicationRoot");
+
     }
 
-    public static final String SERVER_URL = "http://localhost:9085/ma/v1";
+    public static final String SERVER_URL = "http://localhost:" + LIBERTY_PORT + LARS_APPLICATION_ROOT;
 
-    public static final String DEFAULT_DB_NAME = "larsDB";
-
-    public static final String DEFAULT_HOST_AND_PORT = "localhost:27020";
+    public static final String DEFAULT_HOST_AND_PORT = "localhost:" + DB_PORT;
 
     private static final String ADMIN_USERNAME = "admin";
 
@@ -44,7 +66,7 @@ public class FatUtils {
 
     public static final RepositoryFixture FAT_REPO = new RepositoryFixture(SERVER_URL,
             DEFAULT_HOST_AND_PORT,
-            DEFAULT_DB_NAME,
+            TEST_DB_NAME,
             ADMIN_USERNAME,
             ADMIN_PASSWORD,
             USER_ROLE_USERNAME,

--- a/test-utils/src/main/resources/config.properties
+++ b/test-utils/src/main/resources/config.properties
@@ -1,0 +1,16 @@
+# Test Ports
+# ----------
+# Running tests involves starting up instances of mongod and liberty
+# Here you may set the ports that should be used by mongod and liberty during a test run
+# By default they're set differently to the standard ports so that they won't clash with
+# another mongod or liberty running on the same machine
+
+
+# The port that mongod should use for test runs
+testMongoPort=27020
+# The port that liberty should use for test runs
+testLibertyPort=9085
+
+testDbName=larsDB
+
+larsApplicationRoot=/ma/v1


### PR DESCRIPTION
to remove the need to have it hard-coded in several places
