### PR TITLE
Compute the URLs of assets from the request

### DIFF
--- a/server/config/server.xml
+++ b/server/config/server.xml
@@ -65,7 +65,8 @@ limitations under the License.
         <hostNames>localhost</hostNames>
     </mongo>
     
-    <jndiEntry id="lars/URLBase" jndiName="lars/URLBase" value="http://localhost:9080" />
+    <!-- Uncomment this to override the base URL (may be useful if lars is behind a reverse proxy -->
+    <!-- <jndiEntry id="lars/URLBase" jndiName="lars/URLBase" value="http://my.external.domain" /> -->
 
     <mongoDB databaseName="larsDB" jndiName="mongo/larsDB" mongoRef="mongo"/>
 

--- a/server/config/testServer.xml
+++ b/server/config/testServer.xml
@@ -50,7 +50,6 @@ limitations under the License.
     </library>
 
     <httpEndpoint httpPort="@HTTP_PORT@" id="defaultHttpEndpoint"/>
-    <jndiEntry id="lars/URLBase" jndiName="lars/URLBase" value="http://localhost:@HTTP_PORT@" />
 
     <!-- Use slightly safer write concern than the default -->
     <mongo id="mongo" libraryRef="mongo-lib" writeConcern="JOURNAL_SAFE">

--- a/server/src/main/java/com/ibm/ws/lars/rest/Configuration.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/Configuration.java
@@ -17,6 +17,7 @@
 package com.ibm.ws.lars.rest;
 
 import javax.annotation.Resource;
+import javax.ws.rs.core.UriInfo;
 
 /**
  *
@@ -25,17 +26,12 @@ public class Configuration {
 
     @Resource(lookup = "lars/URLBase")
     private String urlBase;
-    // TODO this is a terrible default and we really want to be doing it based
-    // on the HTTP request. See Technical Debt 151580.
-    // Although, doing it by the HTTP request probably isn't going to work in
-    // all cases either.
-    private static final String DEFAULT_URL_BASE = "http://localhost:9080";
 
-    public String getURLBase() {
+    public String getURLBase(UriInfo uriInfo) {
         if (urlBase != null) {
             return urlBase;
         } else {
-            return DEFAULT_URL_BASE;
+            return uriInfo.getBaseUri().toString();
         }
     }
 }

--- a/server/src/main/java/com/ibm/ws/lars/rest/model/Asset.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/model/Asset.java
@@ -46,10 +46,22 @@ public class Asset extends RepositoryObject {
         super();
     }
 
+    /**
+     * Wrap an existing map of properties in an asset object.
+     * <p>
+     * Changes to the asset will be reflected in the original map.
+     *
+     * @param state the map of properties
+     */
     public Asset(Map<String, Object> state) {
         super(state);
     }
 
+    /**
+     * Copy another attachment, creating a new copy of the internal set of properties.
+     *
+     * @param toCopy the attachment to clone
+     */
     public Asset(Asset clone) {
         super(clone);
     }

--- a/server/src/main/java/com/ibm/ws/lars/rest/model/Attachment.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/model/Attachment.java
@@ -30,12 +30,24 @@ public class Attachment extends RepositoryObject {
         super();
     }
 
+    /**
+     * Wrap an existing map of properties in an attachment object.
+     * <p>
+     * Changes to the attachment will be reflected in the original map.
+     *
+     * @param state the map of properties
+     */
     public Attachment(Map<String, Object> state) {
         super(state);
     }
 
-    public Attachment(Attachment clone) {
-        super(clone);
+    /**
+     * Copy another attachment, creating a new copy of the internal set of properties.
+     *
+     * @param toCopy the attachment to clone
+     */
+    public Attachment(Attachment toCopy) {
+        super(toCopy);
     }
 
     public enum LinkType {

--- a/server/src/main/java/com/ibm/ws/lars/rest/model/RepositoryObject.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/model/RepositoryObject.java
@@ -58,11 +58,17 @@ public abstract class RepositoryObject {
      * broken and we'd rather have control of the process.
      */
     protected RepositoryObject(RepositoryObject clone) {
-        this(clone.getProperties());
+        this(new HashMap<>(clone.getProperties()));
     }
 
+    /**
+     * Wrap an existing map of properties in a repository object. Changes to the object will be
+     * reflected in the original map.
+     *
+     * @param properties the map of properties
+     */
     protected RepositoryObject(Map<String, Object> properties) {
-        this.properties = new HashMap<>(properties);
+        this.properties = properties;
     }
 
     protected static Map<String, Object> readJsonState(String json) throws InvalidJsonAssetException {

--- a/server/src/test/java/com/ibm/ws/lars/rest/DummyUriInfo.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/DummyUriInfo.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.lars.rest;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * A dummy UriInfo for unit testing
+ * <p>
+ * Only {@link #getBaseUri()} is implemented
+ */
+public class DummyUriInfo implements UriInfo {
+
+    private final URI baseUri;
+
+    /**
+     * Create a UriInfo with the given base URI
+     */
+    public DummyUriInfo(URI baseUri) {
+        this.baseUri = baseUri;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public URI getBaseUri() {
+        return baseUri;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public URI getAbsolutePath() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public UriBuilder getAbsolutePathBuilder() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public UriBuilder getBaseUriBuilder() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<Object> getMatchedResources() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> getMatchedURIs() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> getMatchedURIs(boolean arg0) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getPath() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getPath(boolean arg0) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MultivaluedMap<String, String> getPathParameters() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MultivaluedMap<String, String> getPathParameters(boolean arg0) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<PathSegment> getPathSegments() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<PathSegment> getPathSegments(boolean arg0) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MultivaluedMap<String, String> getQueryParameters() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MultivaluedMap<String, String> getQueryParameters(boolean arg0) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public URI getRequestUri() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public UriBuilder getRequestUriBuilder() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/server/src/test/java/com/ibm/ws/lars/rest/MemoryPersistor.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/MemoryPersistor.java
@@ -56,7 +56,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#retrieveAllAssets()
      */
     @Override
@@ -72,7 +72,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#retrieveAsset(java.lang.String)
      */
     @Override
@@ -80,7 +80,7 @@ public class MemoryPersistor implements Persistor {
         if (!assets.containsKey(assetId)) {
             throw new NonExistentArtefactException();
         }
-        return Asset.createAssetFromMap(assets.get(assetId));
+        return Asset.createAssetFromMap(new HashMap<>(assets.get(assetId)));
     }
 
     @Override
@@ -94,7 +94,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#deleteAsset(java.lang.String)
      */
     @Override
@@ -104,7 +104,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#updateAsset(java.lang.String,
      * com.ibm.ws.lars.rest.model.Asset)
      */
@@ -116,7 +116,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#findAttachmentsForAsset(java.lang.String)
      */
     @Override
@@ -134,7 +134,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#createAttachmentContent(java.lang.String,
      * java.lang.String, java.io.InputStream)
      */
@@ -166,7 +166,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see
      * com.ibm.ws.lars.rest.Persistor#createAttachmentMetadata(com.ibm.ws.lars.rest.model.Attachment
      * )
@@ -186,7 +186,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#retrieveAttachmentMetadata(java.lang.String)
      */
     @Override
@@ -194,12 +194,12 @@ public class MemoryPersistor implements Persistor {
         if (!attachments.containsKey(attachmentId)) {
             throw new NonExistentArtefactException();
         }
-        return Attachment.createAttachmentFromMap(attachments.get(attachmentId));
+        return Attachment.createAttachmentFromMap(new HashMap<>(attachments.get(attachmentId)));
     }
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#deleteAttachmentContent(java.lang.String)
      */
     @Override
@@ -209,7 +209,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#deleteAttachmentMetadata(java.lang.String)
      */
     @Override
@@ -219,7 +219,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#retrieveAttachmentContent(java.lang.String,
      * java.lang.String, java.lang.String)
      */
@@ -233,7 +233,7 @@ public class MemoryPersistor implements Persistor {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see com.ibm.ws.lars.rest.Persistor#allocateNewId()
      */
     @Override

--- a/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
@@ -29,6 +29,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 
 import org.apache.wink.common.model.multipart.BufferedInMultiPart;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -44,11 +45,18 @@ public class RepositoryRESTResourceLoggingTest {
         return tested;
     }
 
+    private UriInfo dummyUriInfo;
+
     @Mocked
     AssetServiceLayer assetService;
 
     /** ID for an asset which should never exist */
     public static final String NON_EXISTENT_ID = "ffffffffffffffffffffffff";
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        dummyUriInfo = new DummyUriInfo(new URI("http://localhost:9080/"));
+    }
 
     @Test
     public void testGetAsset(@Mocked final Logger logger) throws InvalidIdException, NonExistentArtefactException {
@@ -61,7 +69,7 @@ public class RepositoryRESTResourceLoggingTest {
             }
         };
 
-        getRestResource().getAsset(NON_EXISTENT_ID);
+        getRestResource().getAsset(NON_EXISTENT_ID, dummyUriInfo);
     }
 
     @Test
@@ -128,7 +136,7 @@ public class RepositoryRESTResourceLoggingTest {
             }
         };
 
-        getRestResource().createAttachmentWithContent("name", NON_EXISTENT_ID, null, inMultiPart);
+        getRestResource().createAttachmentWithContent("name", NON_EXISTENT_ID, null, inMultiPart, dummyUriInfo);
     }
 
     @Test
@@ -144,7 +152,7 @@ public class RepositoryRESTResourceLoggingTest {
             }
         };
 
-        getRestResource().createAttachmentNoContent("name", NON_EXISTENT_ID, null, "{}");
+        getRestResource().createAttachmentNoContent("name", NON_EXISTENT_ID, null, "{}", dummyUriInfo);
     }
 
     @Test
@@ -159,7 +167,7 @@ public class RepositoryRESTResourceLoggingTest {
             }
         };
 
-        getRestResource().getAttachments(NON_EXISTENT_ID);
+        getRestResource().getAttachments(NON_EXISTENT_ID, dummyUriInfo);
     }
 
     @Test
@@ -190,7 +198,7 @@ public class RepositoryRESTResourceLoggingTest {
             }
         };
 
-        getRestResource().getAttachmentContent(NON_EXISTENT_ID, NON_EXISTENT_ID, "no_name");
+        getRestResource().getAttachmentContent(NON_EXISTENT_ID, NON_EXISTENT_ID, "no_name", dummyUriInfo);
     }
 
     @Test


### PR DESCRIPTION
This allows us to deploy to any URL without having to specify the base
address in the server.xml

Note that this changes the semantics of the constructors of subclasses
of RepositoryObject. Previously RepositoryObject(Map<String, Object>
properties) would create a copy of the properties map but now it does
not. This makes performing business logic on a list of objects much
easier. (Previously, when iterating through an AttachmentList, any
changes made were not reflected in the original list.)

Some parts of the code have been updated to manually make a copy where
appropriate.

Conflicts:
    server/src/main/java/com/ibm/ws/lars/rest/RepositoryRESTResource.java
