### PR TITLE
Fix nullptr

### DIFF
--- a/upload-lib/src/fat/java/com/ibm/ws/massive/esa/MassiveEsaTest.java
+++ b/upload-lib/src/fat/java/com/ibm/ws/massive/esa/MassiveEsaTest.java
@@ -1672,4 +1672,12 @@ public class MassiveEsaTest {
         featureResource.approve();
     }
 
+    @Test
+    public void testFeatureWithNoSymbolicNameAttributes() throws Throwable {
+        File featureFile = new File(esaDir, "no-symbolic-name-attributes.esa");
+
+        EsaResource featureResource = uploadAsset(featureFile);
+        featureResource.approve();
+    }
+
 }

--- a/upload-lib/src/fat/testResources/no-symbolic-name-attributes.esa/OSGI-INF/SUBSYSTEM.MF
+++ b/upload-lib/src/fat/testResources/no-symbolic-name-attributes.esa/OSGI-INF/SUBSYSTEM.MF
@@ -1,0 +1,16 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: no-symbolic-name-attributes; 
+Subsystem-Version: 1.0.0
+Subsystem-Content: com.example.no.symbolic.name.attributes; version="[1,1.0.100)"
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.example.no.symbolic.name.attributes))",
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.example.no.symbolic.name.attributes))"
+IBM-Install-Policy: when-satisfied
+IBM-App-ForceRestart: install,uninstall
+IBM-ProductID: com.ibm.websphere.appserver
+IBM-AppliesTo: com.ibm.websphere.appserver; productVersion=8.5.5.6
+Subsystem-License: http://www.example.com/the-license
+IBM-License-Agreement: wlp/lafiles/LA
+IBM-InstallTo: core
+Subsystem-Vendor: IBM

--- a/upload-lib/src/fat/testResources/no-symbolic-name-attributes.esa/OSGI-INF/checksums.cs
+++ b/upload-lib/src/fat/testResources/no-symbolic-name-attributes.esa/OSGI-INF/checksums.cs
@@ -1,0 +1,1 @@
+# This checksum file is intentionally blank

--- a/upload-lib/src/main/java/com/ibm/ws/massive/esa/internal/EsaManifest.java
+++ b/upload-lib/src/main/java/com/ibm/ws/massive/esa/internal/EsaManifest.java
@@ -22,7 +22,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -137,6 +139,11 @@ public class EsaManifest {
         NameValuePair nvp = org.apache.aries.util.manifest.ManifestHeaderProcessor.parseBundleSymbolicName(getHeader("Subsystem-SymbolicName"));
         symbolicName = nvp.getName();
         symbolicNameAttrs = nvp.getAttributes();
+        if (symbolicNameAttrs == null) {
+            // Don't leave symbolicNameAttrs as null because it would necessitate
+            // checks in a few other places
+            symbolicNameAttrs = Collections.emptyMap();
+        }
     }
 
     /**


### PR DESCRIPTION
Handle uploading a feature whose Subsystem-SymbolicName has no attributes. Previously, this was failing with a NullPointerException.
