### PR TITLE
Ensure that the parent assetId is valid when an attachment is created

### DIFF
--- a/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
@@ -177,7 +177,16 @@ public class AssetServiceLayer {
     }
 
     private Attachment createAttachment(String assetId, String name, Attachment originalAttachmentMetadata, String contentType,
-                                        InputStream attachmentContentStream, UriInfo uriInfo) throws InvalidJsonAssetException, AssetPersistenceException {
+                                        InputStream attachmentContentStream, UriInfo uriInfo) throws InvalidJsonAssetException, AssetPersistenceException, NonExistentArtefactException {
+
+        // Check that the parent exists
+        try {
+            persistenceBean.retrieveAsset(assetId);
+        } catch (NonExistentArtefactException e) {
+            // The message from the PersistenceLayer is unhelpful in this context, so send back a better one
+            throw new NonExistentArtefactException("The parent asset for this attachment (id="
+                                                   + assetId + ") does not exist in the repository.");
+        }
 
         Attachment attachmentMetadata = new Attachment(originalAttachmentMetadata);
 
@@ -213,7 +222,7 @@ public class AssetServiceLayer {
     }
 
     public Attachment createAttachmentWithContent(String assetId, String name, Attachment attachmentMetadata, String contentType,
-                                                  InputStream attachmentContentStream, UriInfo uriInfo) throws InvalidJsonAssetException, AssetPersistenceException {
+                                                  InputStream attachmentContentStream, UriInfo uriInfo) throws InvalidJsonAssetException, AssetPersistenceException, NonExistentArtefactException {
 
         // The attachment has content, so the URL must not be set, and the
         // linkType must not be set (i.e. it must be null).
@@ -242,9 +251,10 @@ public class AssetServiceLayer {
      * @return
      * @throws InvalidJsonAssetException
      * @throws AssetPersistenceException
+     * @throws NonExistentArtefactException
      */
     public Attachment createAttachmentNoContent(String assetId, String name, Attachment attachmentMetadata, UriInfo uriInfo) throws InvalidJsonAssetException,
-            AssetPersistenceException {
+            AssetPersistenceException, NonExistentArtefactException {
 
         // There is no content, so an external URL must be set, and the link
         // type must be DIRECT or WEB_PAGE

--- a/server/src/main/java/com/ibm/ws/lars/rest/NonExistentArtefactException.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/NonExistentArtefactException.java
@@ -35,6 +35,10 @@ public class NonExistentArtefactException extends RepositoryClientException {
         super(type + " not found for id: " + id);
     }
 
+    public NonExistentArtefactException(String message) {
+        super(message);
+    }
+
     /** {@inheritDoc} */
     @Override
     public Status getResponseStatus() {

--- a/server/src/main/java/com/ibm/ws/lars/rest/PersistenceBean.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/PersistenceBean.java
@@ -235,8 +235,8 @@ public class PersistenceBean implements Persistor {
     /**
      * Retrieve a single asset by its id.
      *
-     * @return A json string, or null if the asset doesn't exist
-     * @throws AssetNotFoundException
+     * @return The requested asset
+     * @throws AssetNotFoundException if the asset doesn't exist
      */
     private Asset retrieveAsset(ObjectId assetId) throws NonExistentArtefactException {
         BasicDBObject query = new BasicDBObject(ID, assetId);

--- a/server/src/main/java/com/ibm/ws/lars/rest/RepositoryClientException.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/RepositoryClientException.java
@@ -19,7 +19,7 @@ package com.ibm.ws.lars.rest;
 import javax.ws.rs.core.Response;
 
 /**
- *
+ * An exception which represents an error in input data from the client
  */
 public abstract class RepositoryClientException extends Exception {
 

--- a/server/src/main/java/com/ibm/ws/lars/rest/RepositoryRESTResource.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/RepositoryRESTResource.java
@@ -257,7 +257,7 @@ public class RepositoryRESTResource {
                                                 @Context HttpServletRequest request,
                                                 BufferedInMultiPart inMultiPart,
                                                 @Context UriInfo uriInfo
-            ) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException {
+            ) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException, NonExistentArtefactException {
 
         if (logger.isLoggable(Level.FINE)) {
             logger.fine("createAttachmentWithContent called, name: " + name + " assetId: " + assetId);
@@ -297,7 +297,7 @@ public class RepositoryRESTResource {
                                               @PathParam("assetId") String assetId,
                                               @Context HttpServletRequest request,
                                               String bodyJSON,
-                                              @Context UriInfo uriInfo) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException {
+                                              @Context UriInfo uriInfo) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException, NonExistentArtefactException {
 
         if (logger.isLoggable(Level.FINE)) {
             logger.fine("createAttachmentNoContent called, name: " + name

--- a/server/src/test/java/com/ibm/ws/lars/rest/AssetServiceLayerTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/AssetServiceLayerTest.java
@@ -155,7 +155,7 @@ public class AssetServiceLayerTest {
      * content and no url.
      */
     @Test
-    public void testAddAttachmentNoContentNoUrl() throws InvalidJsonAssetException, AssetPersistenceException {
+    public void testAddAttachmentNoContentNoUrl() throws InvalidJsonAssetException, AssetPersistenceException, NonExistentArtefactException {
         thrown.expect(InvalidJsonAssetException.class);
         thrown.expectMessage("The URL of the supplied attachment was null");
         String attachmentJSON = "{\"foo\":\"bar\"}";
@@ -170,7 +170,7 @@ public class AssetServiceLayerTest {
      * content and no linkType.
      */
     @Test
-    public void testAddAttachmentNoContentNoLinkType() throws InvalidJsonAssetException, AssetPersistenceException {
+    public void testAddAttachmentNoContentNoLinkType() throws InvalidJsonAssetException, AssetPersistenceException, NonExistentArtefactException {
         thrown.expect(InvalidJsonAssetException.class);
         thrown.expectMessage("The link type for the attachment was not set.");
         String attachmentJSON = "{\"url\":\"http://example.com\"}";
@@ -185,7 +185,7 @@ public class AssetServiceLayerTest {
      * and a linkType that is not valid.
      */
     @Test
-    public void testAddAttachmentNoContentBadLinkType() throws InvalidJsonAssetException, AssetPersistenceException {
+    public void testAddAttachmentNoContentBadLinkType() throws InvalidJsonAssetException, AssetPersistenceException, NonExistentArtefactException {
         thrown.expect(InvalidJsonAssetException.class);
         thrown.expectMessage("The link type for the attachment was set to an invalid value: Foobar");
         String attachmentJSON = "{\"url\":\"http://example.com\"}";
@@ -288,6 +288,23 @@ public class AssetServiceLayerTest {
         attachmentToCreate.setLinkType("foobar");
         service.createAttachmentWithContent(returnedAsset.get_id(), "AttachmentWithContent.txt", attachmentToCreate, "text/plain",
                                             new ByteArrayInputStream(attachmentContent), dummyUriInfo);
+    }
+
+    /**
+     * Tests that an exception is thrown if an attachment is created with an invalid parent asset
+     * id.
+     *
+     * @throws InvalidJsonAssetException
+     * @throws NonExistentArtefactException
+     * @throws AssetPersistenceException
+     */
+    @Test
+    public void testAddAttachmentInvalidAssetId() throws InvalidJsonAssetException, NonExistentArtefactException, AssetPersistenceException {
+        thrown.expect(NonExistentArtefactException.class);
+        thrown.expectMessage("The parent asset for this attachment (id=FFFFFFFFFFFFFFFF) does not exist in the repository.");
+        String attachmentJSON = "{\"url\":\"http://example.com\", \"linkType\":\"direct\"}";
+        Attachment attachment = Attachment.jsonToAttachment(attachmentJSON);
+        service.createAttachmentNoContent("FFFFFFFFFFFFFFFF", "Mr Attachment", attachment, dummyUriInfo);
     }
 
     /**

--- a/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
@@ -125,7 +125,7 @@ public class RepositoryRESTResourceLoggingTest {
     }
 
     @Test
-    public void testCreateAttachmentWithContent(@Mocked final Logger logger, @Mocked final BufferedInMultiPart inMultiPart) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException {
+    public void testCreateAttachmentWithContent(@Mocked final Logger logger, @Mocked final BufferedInMultiPart inMultiPart) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException, NonExistentArtefactException {
 
         new Expectations() {
             {
@@ -140,7 +140,7 @@ public class RepositoryRESTResourceLoggingTest {
     }
 
     @Test
-    public void testCreateAttachmentNoContent(@Mocked final Logger logger) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException {
+    public void testCreateAttachmentNoContent(@Mocked final Logger logger) throws InvalidJsonAssetException, InvalidIdException, AssetPersistenceException, NonExistentArtefactException {
 
         new Expectations() {
             {


### PR DESCRIPTION
Otherwise a client could create an orphaned attachment
