### PR TITLE
LARS bulk uploader

### DIFF
--- a/cli-client/src/fat/java/com/ibm/ws/lars/upload/cli/UploadFatTest.java
+++ b/cli-client/src/fat/java/com/ibm/ws/lars/upload/cli/UploadFatTest.java
@@ -160,4 +160,24 @@ public class UploadFatTest {
 
         tp.assertOutputContains("done");
     }
+
+    @Test
+    public void shouldUploadDirectory() throws Exception {
+        LoginInfo loginInfo = repoServer.getLoginInfo();
+
+        // Note: at the time of writing, dirWith3ESAs has a subdirectory that contains
+        // ESAs. We do *not* expect the contents of the subdirectory to be uploaded
+        // (and the test will fail if they *are* uploaded).
+        TestProcess tp = new TestProcess(Arrays.asList(FatUtils.SCRIPT,
+                                                       "upload",
+                                                       "--url=" + FatUtils.SERVER_URL,
+                                                       "--username=" + repoServer.getLoginInfoEntry().getUserId(),
+                                                       "--password=" + repoServer.getLoginInfoEntry().getPassword(),
+                                                       "resources/dirWith3ESAs"));
+        tp.run();
+
+        tp.assertReturnCode(0);
+        assertEquals("Incorrect resource count", 3, MassiveResource.getAllResources(loginInfo).size());
+        assertEquals("Incorrect feature count", 3, EsaResource.getAllFeatures(loginInfo).size());
+    }
 }

--- a/cli-client/src/fat/testResources/dirWith3ESAs/VersionRange.esa/OSGI-INF/SUBSYSTEM.MF
+++ b/cli-client/src/fat/testResources/dirWith3ESAs/VersionRange.esa/OSGI-INF/SUBSYSTEM.MF
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: com.ibm.ws.test.versionrange;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+Subsystem-Vendor: IBM
+IBM-AppliesTo: com.ibm.websphere.appserver;productVersion=8.5.5.1+;

--- a/cli-client/src/fat/testResources/dirWith3ESAs/dirWithESAsThatShouldNotBeUploadedWithoutRecursiveFlag/anotherFeature.esa/OSGI-INF/SUBSYSTEM.MF
+++ b/cli-client/src/fat/testResources/dirWith3ESAs/dirWithESAsThatShouldNotBeUploadedWithoutRecursiveFlag/anotherFeature.esa/OSGI-INF/SUBSYSTEM.MF
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: com.ibm.ws.test.anotherFeature;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+Subsystem-Vendor: IBM
+

--- a/cli-client/src/fat/testResources/dirWith3ESAs/iplaLicensedFeature.esa/OSGI-INF/SUBSYSTEM.MF
+++ b/cli-client/src/fat/testResources/dirWith3ESAs/iplaLicensedFeature.esa/OSGI-INF/SUBSYSTEM.MF
@@ -1,0 +1,6 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: com.ibm.ws.test.simple;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+Subsystem-Vendor: IBM

--- a/cli-client/src/fat/testResources/dirWith3ESAs/userFeature.esa/OSGI-INF/SUBSYSTEM.MF
+++ b/cli-client/src/fat/testResources/dirWith3ESAs/userFeature.esa/OSGI-INF/SUBSYSTEM.MF
@@ -1,0 +1,6 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: com.ibm.ws.test.userFeature;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+Subsystem-Vendor: IBM

--- a/cli-client/src/test/java/com/ibm/ws/lars/upload/cli/UploadTest.java
+++ b/cli-client/src/test/java/com/ibm/ws/lars/upload/cli/UploadTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayOutputStream;
 import java.io.Console;
 import java.io.File;
+import java.io.FileFilter;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +41,11 @@ import org.junit.Test;
 
 import com.ibm.ws.lars.upload.cli.ClientException.HelpDisplay;
 import com.ibm.ws.massive.LoginInfoEntry;
+import com.ibm.ws.massive.RepositoryBackendIOException;
 import com.ibm.ws.massive.esa.MassiveEsa;
+import com.ibm.ws.massive.resources.AddThenDeleteStrategy;
 import com.ibm.ws.massive.resources.EsaResource;
+import com.ibm.ws.massive.resources.MassiveResource;
 import com.ibm.ws.massive.resources.UploadStrategy;
 
 /**
@@ -94,10 +98,7 @@ public class UploadTest {
         }
     }
 
-    /**
-     * Mock directory
-     */
-    public static class MockDirectory extends MockUp<File> {
+    public static class MockEmptyDirectory extends MockUp<File> {
         @Mock
         public boolean canRead(Invocation inv) {
             return true;
@@ -106,6 +107,111 @@ public class UploadTest {
         @Mock
         public boolean isDirectory(Invocation inv) {
             return true;
+        }
+    }
+
+    /**
+     * Mocks up a directory structure that looks like this:
+     *
+     * <pre>
+     * superDirectory
+     *   cheese.esa
+     *   ston.ese
+     *   I_am_not_a_feature.txt
+     *   subDirectory
+     *     dontUploadThis.esa
+     * </pre>
+     */
+    public static class MockDirectoryWithFiles extends MockUp<File> {
+        @Mock
+        public boolean canRead(Invocation inv) {
+            return true;
+        }
+
+        @Mock
+        public boolean isDirectory(Invocation inv) {
+            String name = ((File) inv.getInvokedInstance()).getName();
+            return "superDirectory".equals(name) ||
+                   "subDirectory".equals(name);
+        }
+
+        @Mock
+        public File[] listFiles(Invocation inv, FileFilter filter) {
+            final List<File> files;
+            File thiz = (File) inv.getInvokedInstance();
+            String name = thiz.getName();
+
+            if ("superDirectory".equals(name)) {
+                files = Arrays.asList(new File(thiz, "cheese.esa"),
+                                      new File(thiz, "ston.esa"),
+                                      new File(thiz, "I_am_not_a_feature.txt"),
+                                      new File(thiz, "subDirectory"));
+            } else if ("subDirectory".equals(name)) {
+                files = Arrays.asList(new File(thiz, "dontUploadThis.esa"));
+            } else {
+                return null;
+            }
+
+            List<File> filteredFiles = new ArrayList<File>();
+            for (File f : files) {
+                if (filter.accept(f)) {
+                    filteredFiles.add(f);
+                }
+            }
+            return filteredFiles.toArray(new File[filteredFiles.size()]);
+        }
+    }
+
+    /**
+     * Mocked up AddThenDeleteStrategy that claims to have deleted the specified number of
+     * resources.
+     */
+    public static class MockAddThenDeleteStrategy extends MockUp<AddThenDeleteStrategy> {
+
+        private final int numDeletedResources;
+
+        public MockAddThenDeleteStrategy(int numDeletedResources) {
+            this.numDeletedResources = numDeletedResources;
+        }
+
+        @Mock
+        public List<MassiveResource> getDeletedResources() {
+            try {
+                ArrayList<MassiveResource> result = new ArrayList<>();
+                for (int i = 0; i < numDeletedResources; i++) {
+                    result.add(new EsaResource(new LoginInfoEntry()));
+                }
+                return result;
+            } catch (RepositoryBackendIOException e) {
+                throw new AssertionError();
+            }
+        }
+    }
+
+    public static class MockEsaResource extends MockUp<EsaResource> {
+        @Mock
+        public String getName() {
+            return "a-fake-name";
+        }
+
+        @Mock
+        public MassiveResource.Type getType() {
+            return MassiveResource.Type.FEATURE;
+        }
+
+        @Mock
+        public String getAppliesTo() {
+            return "fake-applies-to";
+        }
+
+        @Mock
+        public String getVersion() {
+            return "1.2.3.4";
+        }
+
+        @Mock
+        public String getProvideFeature() {
+            return "a-fake-feature";
         }
     }
 
@@ -127,9 +233,9 @@ public class UploadTest {
     }
 
     @Test
-    public void testDirectory() {
+    public void testEmptyDirectoryShouldResultInNoFilesError() {
         new MockUploader();
-        new MockDirectory();
+        new MockEmptyDirectory();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -139,8 +245,8 @@ public class UploadTest {
             fail("ClientException not thrown");
         } catch (ClientException ex) {
             assertEquals("Wrong return code", 1, ex.getReturnCode());
-            assertEquals("Wrong error message", "File TestFile.esa is a directory", ex.getMessage());
-            assertEquals("Wrong help display", HelpDisplay.NO_HELP, ex.getHelpDisplay());
+            assertEquals("Wrong error message", Main.NO_FILES, ex.getMessage());
+            assertEquals("Wrong help display", HelpDisplay.SHOW_HELP, ex.getHelpDisplay());
         }
     }
 
@@ -283,5 +389,84 @@ public class UploadTest {
         main.run(new String[] { "--upload", "--url=http://example.org", "TestFile.esa" });
         // call count should not have increased here
         assertEquals("Wrong number of calls to readPassword", 1, mockConsole.count);
+    }
+
+    @Test
+    public void testShouldUploadContentsOfDirectory() throws Exception {
+        MockUploader uploader = new MockUploader();
+        new MockDirectoryWithFiles();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Main main = new Main(new PrintStream(out));
+
+        main.run(new String[] { "--upload", "--url=http://example.org", "superDirectory" });
+
+        assertEquals("Wrong files uploaded", Arrays.asList("cheese.esa", "ston.esa"), uploader.getFilesUploaded());
+        assertThat("Output incorrect", out.toString(), containsString("Uploading superDirectory/cheese.esa ... done"));
+        assertThat("Output incorrect", out.toString(), containsString("Uploading superDirectory/ston.esa ... done"));
+    }
+
+    @Test
+    public void testShouldGiveProgressIndication() throws Exception {
+        MockUploader uploader = new MockUploader();
+        new MockDirectoryWithFiles();
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+
+        Main main = new Main(new PrintStream(outStream));
+
+        main.run(new String[] { "--upload", "--url=http://example.org", "superDirectory", "i-am-a-feature.esa" });
+
+        String output = outStream.toString();
+
+        assertThat("Output incorrect", output, containsString("1 of 3: Uploading superDirectory/cheese.esa"));
+        assertThat("Output incorrect", output, containsString("2 of 3: Uploading superDirectory/ston.esa"));
+        assertThat("Output incorrect", output, containsString("3 of 3: Uploading i-am-a-feature.esa"));
+    }
+
+    @Test
+    public void shouldGiveIndicationIfExistingResourceReplaced() throws Exception {
+        new MockUploader();
+
+        new MockDirectoryWithFiles();
+
+        new MockAddThenDeleteStrategy(1);
+
+        new MockEsaResource();
+
+        // The mocks that we define above make the uploader think that an existing ESA
+        // has been deleted when we upload our new resource.
+        // We verify that we get a message telling us that the pre-existing file was deleted
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        Main main2 = new Main(new PrintStream(outStream));
+        main2.run(new String[] { "--upload", "--url=http://example.org", "superDirectory/cheese.esa" });
+
+        assertThat("Output incorrect", outStream.toString(),
+                   containsString("1 of 1: Uploading superDirectory/cheese.esa ... done, replacing existing asset " +
+                                  "a-fake-name type=FEATURE, appliesTo=fake-applies-to, " +
+                                  "version=1.2.3.4, provideFeature=a-fake-feature"));
+    }
+
+    @Test
+    public void shouldGiveIndicationIfMultipleExistingResourceReplaced() throws Exception {
+        new MockUploader();
+
+        new MockDirectoryWithFiles();
+
+        new MockAddThenDeleteStrategy(2);
+
+        new MockEsaResource();
+
+        // The mocks that we define above make the uploader think that two existing ESAs
+        // have been deleted when we upload our new resource.
+        // We verify that we get a message telling us that the pre-existing files were deleted
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        Main main2 = new Main(new PrintStream(outStream));
+        main2.run(new String[] { "--upload", "--url=http://example.org", "superDirectory/cheese.esa" });
+
+        assertEquals("Output incorrect",
+                     "1 of 1: Uploading superDirectory/cheese.esa ... done, replacing multiple duplicate assets:\n" +
+                             "a-fake-name type=FEATURE, appliesTo=fake-applies-to, version=1.2.3.4, provideFeature=a-fake-feature\n" +
+                             "a-fake-name type=FEATURE, appliesTo=fake-applies-to, version=1.2.3.4, provideFeature=a-fake-feature\n",
+                     outStream.toString());
     }
 }


### PR DESCRIPTION
This gives larsClient a basic  "bulk upload" capability. If you pass a directory to larsClient, it will upload all .esa files found in that directory (but not its subdirectories) to LARS.

This pull request also adds a progress indicator ("1 of 10: Uploading  file x.esa ...").

Finally, it also makes larsClient tell the user if an upload causes an existing asset to be replaced.
