### PR TITLE
Move the repository definitions centrally and move dependency versions

### DIFF
--- a/LARS-1_versions.gradle
+++ b/LARS-1_versions.gradle
@@ -1,0 +1,26 @@
+/*
+ * The purpose of this file is to provide fixed versions of some
+ * dependencies to build against for v1 release. To build against
+ * these version run the gradle build with:
+ * 
+ *   -PversionFile=LARS-1_versions.gradle
+ */
+
+ext {
+	// Packaged runtime dependencies
+	// Fixed versions for the LARS 1 release
+	aries_util_version = "1.1.0"
+	osgi_core_version = "5.0.0"
+	jackson_version="2.4.4"
+	wink_json4j_version="1.4"
+	mongodb_java_version="2.11.1"
+
+	// Test/compile time only dependencies
+	// Fixed at 1.15 as 1.16beta was getting picked up, which had a bug in it.	
+	jmockit_version="1.15"
+	hamcrest_version="1.+"
+	junit_version="4.+"
+	httpclient_version="4.3.+"
+	httpmime_version="4.3.+"
+	wlp_ant_tasks_version="1.0"
+}

--- a/LARS_versions.gradle
+++ b/LARS_versions.gradle
@@ -1,0 +1,17 @@
+ext {
+	// Packaged runtime dependencies
+	aries_util_version = "1.1.+"
+	osgi_core_version = "5.0.+"
+	jackson_version="2.2.+"
+	wink_json4j_version="1.4"
+	mongodb_java_version="2.11.1"
+
+	// Test/compile time only dependencies
+	// Fixed at 1.15 as 1.16beta was getting picked up, which had a bug in it.
+	jmockit_version="1.15"
+	hamcrest_version="1.+"
+	junit_version="4.+"
+	httpclient_version="4.3.+"
+	httpmime_version="4.3.+"
+	wlp_ant_tasks_version="1.0"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@
 apply plugin: 'base'
 apply plugin: 'eclipse'
 
+if (hasProperty('versionFile')) {
+    apply from: versionFile
+} else {
+    apply from: 'LARS_versions.gradle'
+}
+
 boolean haveAnyTestsFailed = false;
 
 loadProperties("${rootProject.rootDir}/test-utils/src/main/resources/config.properties");
@@ -29,6 +35,11 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'eclipse'
     apply plugin: 'findbugs'
+    
+
+    repositories {
+        mavenCentral()
+    }
     
     sourceSets {
         fat {
@@ -46,10 +57,10 @@ subprojects {
     }
     
     findbugsMain {
-    	reports {
-	        xml.enabled = false
-	        html.enabled = true
-	    }
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
     }
     
     configurations {
@@ -148,7 +159,7 @@ subprojects {
 task dist(type: Sync) {
     into 'build/distributions'
     from subprojects*.getTasksByName('distZip', false)
-	from tasks.getByPath(':server:packageLars');
+    from tasks.getByPath(':server:packageLars');
 }
 
 task globalTestReport(type: TestReport) {

--- a/cli-client/build.gradle
+++ b/cli-client/build.gradle
@@ -20,19 +20,15 @@ apply plugin: 'distribution'
 
 archivesBaseName = 'larsClient'
 
-repositories {
-    mavenCentral();
-}
-
 dependencies {
-    compile group:'org.apache.aries', name:'org.apache.aries.util', version:'1.1.+'
-    compile group:'org.osgi', name:'org.osgi.core', version:'5.0.+'
+    compile group:'org.apache.aries', name:'org.apache.aries.util', version:aries_util_version
+    compile group:'org.osgi', name:'org.osgi.core', version:osgi_core_version
     compile project(':upload-lib')
 
-    testCompile group:'org.jmockit', name:'jmockit', version:'1.15'
-    testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.+'
-    testCompile group:'junit', name:'junit', version:'4.+'
-    testCompile group:'org.mongodb', name:'mongo-java-driver', version:'2.11.1'
+    testCompile group:'org.jmockit', name:'jmockit', version:jmockit_version
+    testCompile group:'org.hamcrest', name:'hamcrest-library', version:hamcrest_version
+    testCompile group:'junit', name:'junit', version:junit_version
+    testCompile group:'org.mongodb', name:'mongo-java-driver', version:mongodb_java_version
     testCompile project(':test-utils')
 }
 

--- a/client-lib-tests/build.gradle
+++ b/client-lib-tests/build.gradle
@@ -17,10 +17,6 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-repositories {
-    mavenCentral();
-}
-
 dependencies {
     testCompile project(':client-lib')
     testCompile project(':test-utils')

--- a/client-lib/build.gradle
+++ b/client-lib/build.gradle
@@ -17,14 +17,10 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-repositories {
-    mavenCentral();
-}
-
 dependencies {
-    compile group:'org.apache.aries', name:'org.apache.aries.util', version:'1.1.+'
-    compile group:'org.osgi', name:'org.osgi.core', version:'5.0.+'
-    compile group:'org.apache.wink', name:'wink-json4j', version:'1.4'
+    compile group:'org.apache.aries', name:'org.apache.aries.util', version:aries_util_version
+    compile group:'org.osgi', name:'org.osgi.core', version:osgi_core_version
+    compile group:'org.apache.wink', name:'wink-json4j', version:wink_json4j_version
 }
 
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,10 +31,6 @@ ext {
     testServerName = 'testServer'
 }
 
-repositories {
-    mavenCentral();
-}
-
 configurations {
     sharedLibs
     providedCompile.extendsFrom sharedLibs
@@ -42,25 +38,25 @@ configurations {
 }
 
 dependencies {
-    compile group:'com.fasterxml.jackson.core', name:'jackson-core', version:'2.2.+'
-    compile group:'com.fasterxml.jackson.core', name:'jackson-databind', version:'2.2.+'
-    compile group:'com.fasterxml.jackson.core', name:'jackson-annotations', version:'2.2.+'
+    compile group:'com.fasterxml.jackson.core', name:'jackson-core', version:jackson_version
+    compile group:'com.fasterxml.jackson.core', name:'jackson-databind', version:jackson_version
+    compile group:'com.fasterxml.jackson.core', name:'jackson-annotations', version:jackson_version
     
-    sharedLibs group:'org.mongodb', name:'mongo-java-driver', version:'2.11.1'
+    sharedLibs group:'org.mongodb', name:'mongo-java-driver', version:mongodb_java_version
     providedCompile fileTree(dir: "${libertyRoot}/dev/api", include: '**/*.jar')
 
-    testCompile group:'junit', name:'junit', version:'4.+'
-    testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.+'
-    testCompile group:'org.apache.httpcomponents', name:'httpclient', version:'4.3.+'
-    testCompile group:'org.apache.httpcomponents', name:'httpmime', version:'4.3.+'
-    testCompile group:'org.jmockit', name:'jmockit', version:'1.15'
+    testCompile group:'junit', name:'junit', version:junit_version
+    testCompile group:'org.hamcrest', name:'hamcrest-library', version:hamcrest_version
+    testCompile group:'org.apache.httpcomponents', name:'httpclient', version:httpclient_version
+    testCompile group:'org.apache.httpcomponents', name:'httpmime', version:httpmime_version
+    testCompile group:'org.jmockit', name:'jmockit', version:jmockit_version
     testCompile project(':test-utils')
     
     // The unit tests need some Liberty classes at runtime, but they should
     // not be compiling against these.
     testRuntime fileTree(dir: "${libertyRoot}/lib", include: '*slf4*.jar')
     
-    antTasks group:'net.wasdev.wlp.ant', name:'wlp-anttasks', version:'1.0'
+    antTasks group:'net.wasdev.wlp.ant', name:'wlp-anttasks', version:wlp_ant_tasks_version
 }
 
 clean {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -17,14 +17,10 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-repositories {
-    mavenCentral();
-}
-
 dependencies {
-    compile group:'org.hamcrest', name:'hamcrest-library', version:'1.+'
-    compile group:'junit', name:'junit', version:'4.+'
-    compile group:'org.mongodb', name:'mongo-java-driver', version:'2.11.1'
+    compile group:'org.hamcrest', name:'hamcrest-library', version:hamcrest_version
+    compile group:'junit', name:'junit', version:junit_version
+    compile group:'org.mongodb', name:'mongo-java-driver', version:mongodb_java_version
     compile project(':client-lib')
 }
 

--- a/upload-lib/build.gradle
+++ b/upload-lib/build.gradle
@@ -17,13 +17,9 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-repositories {
-    mavenCentral();
-}
-
 dependencies {
     compile project(':client-lib')
-    testCompile group:'junit', name:'junit', version:'4.+'
+    testCompile group:'junit', name:'junit', version:junit_version
     testCompile project(':test-utils')
 }
 


### PR DESCRIPTION
to a configuration file. Avoids duplication, and allows fixing versions
more easily
