### PR TITLE
Remove a few TODOs which are no longer valid

### DIFF
--- a/server/src/main/java/com/ibm/ws/lars/rest/model/Asset.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/model/Asset.java
@@ -27,9 +27,6 @@ import com.ibm.ws.lars.rest.RepositoryException;
  * Enforces the constrains on a JSON document to turn it into a Asset as required by the asset
  * service.
  *
- * TODO: client test suite failures<br>
- * - do we need a review object?<br>
- * - should a private asset skip the awaiting approval stage?
  */
 public class Asset extends RepositoryObject {
 

--- a/server/src/test/java/com/ibm/ws/lars/rest/DummyUriInfo.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/DummyUriInfo.java
@@ -48,112 +48,96 @@ public class DummyUriInfo implements UriInfo {
     /** {@inheritDoc} */
     @Override
     public URI getAbsolutePath() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public UriBuilder getAbsolutePathBuilder() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public UriBuilder getBaseUriBuilder() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public List<Object> getMatchedResources() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public List<String> getMatchedURIs() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public List<String> getMatchedURIs(boolean arg0) {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public String getPath() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public String getPath(boolean arg0) {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public MultivaluedMap<String, String> getPathParameters() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public MultivaluedMap<String, String> getPathParameters(boolean arg0) {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public List<PathSegment> getPathSegments() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public List<PathSegment> getPathSegments(boolean arg0) {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public MultivaluedMap<String, String> getQueryParameters() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public MultivaluedMap<String, String> getQueryParameters(boolean arg0) {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public URI getRequestUri() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     /** {@inheritDoc} */
     @Override
     public UriBuilder getRequestUriBuilder() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/server/src/test/java/com/ibm/ws/lars/rest/PersistenceBeanTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/PersistenceBeanTest.java
@@ -48,7 +48,7 @@ import com.mongodb.WriteConcern;
 
 public class PersistenceBeanTest {
 
-    // TODO read all this stuff from config somewhere
+    // TODO Should the db name be configurable?
     private static final String DB_NAME = "testdb";
     private static final WriteConcern WRITE_CONCERN = WriteConcern.JOURNAL_SAFE;
 

--- a/upload-lib/src/fat/java/com/ibm/ws/massive/esa/MassiveEsaTest.java
+++ b/upload-lib/src/fat/java/com/ibm/ws/massive/esa/MassiveEsaTest.java
@@ -1581,7 +1581,8 @@ public class MassiveEsaTest {
 
     @Test
     @Ignore
-    // TODO Story 144391 (port elastic search) must be delivered before the tests @Ignore can be removed
+    // LARS needs to support search before the tests @Ignore can be removed
+    // TODO: check whether the current mongo based search implementation is sufficient
     /**
      * Based on a small set of features make searches to see whether the correct results match each query
      * @throws Throwable


### PR DESCRIPTION
implemented in LARS
These stubs are never going to be filled out, so having TODO comments is
pointless
Most config has already been moved to being read in from file, just the
DB_NAME left
Search has been implemented using mongodb text indexing, so some of
these tests may now pass.
