### PR TITLE
Run API tests against HTTPS endpoint as well as against HTTP.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -134,7 +134,8 @@ task createTestUsrDir (type: Copy) {
     from('config/testServer.xml') {
         into "servers/${testServerName}"
         rename 'testServer\\.xml', 'server.xml'
-        filter(ReplaceTokens, tokens:['HTTP_PORT':testLibertyPort,
+        filter(ReplaceTokens, tokens:['HTTP_PORT':testLibertyPortHTTP,
+                                      'HTTPS_PORT':testLibertyPortHTTPS,
                                       'TEST_DB_NAME':testDbName,
                                       'MONGO_PORT':testMongoPort,
                                       'LIBERTY_TRACE_SPEC':libertyTraceSpec])

--- a/server/config/testServer.xml
+++ b/server/config/testServer.xml
@@ -47,7 +47,7 @@ limitations under the License.
         <file name="${shared.resource.dir}/libs/mongo-java-driver-2.11.1.jar"/>
     </library>
 
-    <httpEndpoint httpPort="@HTTP_PORT@" id="defaultHttpEndpoint"/>
+    <httpEndpoint httpPort="@HTTP_PORT@" httpsPort="@HTTPS_PORT@" id="defaultHttpEndpoint"/>
 
     <!-- Use slightly safer write concern than the default -->
     <mongo id="mongo" libraryRef="mongo-lib" writeConcern="JOURNAL_SAFE">

--- a/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
@@ -27,6 +27,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+import com.ibm.ws.lars.rest.RepositoryContext.Protocol;
 import com.ibm.ws.lars.rest.model.Asset;
 import com.ibm.ws.lars.rest.model.AssetList;
 import com.ibm.ws.lars.rest.model.Attachment;
@@ -61,11 +66,8 @@ import com.mongodb.WriteConcern;
  * Tests required: GET,POST,PUT,DELETE ON /assets GET,POST,PUT,DELETE ON /assets/{asset_id}
  *
  * With variations for good/error cases
- *
- *
- *
- *
  */
+@RunWith(Parameterized.class)
 public class ApiTest {
 
     /** ID for an asset which should never exist */
@@ -75,7 +77,17 @@ public class ApiTest {
     private Random random;
 
     @Rule
-    public RepositoryContext repository = RepositoryContext.createAsAdmin(true);
+    public final RepositoryContext repository;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] { { Protocol.HTTP },
+                                             { Protocol.HTTPS } });
+    }
+
+    public ApiTest(Protocol protocol) {
+        this.repository = RepositoryContext.createAsAdmin(true, protocol);
+    }
 
     @Before
     public void setUp() throws FileNotFoundException, IOException, InvalidJsonAssetException {

--- a/server/src/fat/java/com/ibm/ws/lars/rest/ImCompatibilityTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ImCompatibilityTest.java
@@ -25,13 +25,16 @@ import java.util.Properties;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.ibm.ws.lars.rest.RepositoryContext.Protocol;
+
 /**
  * Tests to check any additional requirements needed to support Installation Manager
  */
 public class ImCompatibilityTest {
 
+    // Note that we only run this test against HTTPS (not HTTP).
     @Rule
-    public RepositoryContext context = RepositoryContext.createAsUser();
+    public RepositoryContext context = RepositoryContext.createAsUser(Protocol.HTTPS);
 
     @Test
     public void testRepositoryConfig() throws Exception {

--- a/server/src/fat/java/com/ibm/ws/lars/rest/PermissionTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/PermissionTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.ibm.ws.lars.rest.RepositoryContext.Protocol;
 import com.ibm.ws.lars.rest.model.Asset;
 import com.ibm.ws.lars.rest.model.AssetList;
 import com.ibm.ws.lars.rest.model.Attachment;
@@ -52,16 +53,28 @@ public class PermissionTest {
     public RepositoryContext userContext;
 
     /**
-     * URL for the test instance where read operations are restricted to users with the User role.
+     * HTTP URL for the test instance where read operations are restricted to users with the User role.
      */
-    private static final String RESTRICTED_URL = RepositoryContext.DEFAULT_URL;
+    private static final String RESTRICTED_URL_HTTP = RepositoryContext.DEFAULT_URLS.get(Protocol.HTTP);
 
     /**
-     * URL for the test instance where read operations are unrestricted.
+     * HTTPS URL for the test instance where read operations are restricted to users with the User role.
+     */
+    private static final String RESTRICTED_URL_HTTPS = RepositoryContext.DEFAULT_URLS.get(Protocol.HTTPS);
+
+    /**
+     * HTTP URL for the test instance where read operations are unrestricted.
      * <p>
      * Write operations are still restricted to users with the Admin role.
      */
-    private static final String UNRESTRICTED_URL = "http://localhost:" + FatUtils.LIBERTY_PORT + "/unrestricted" + FatUtils.LARS_APPLICATION_ROOT;
+    private static final String UNRESTRICTED_URL_HTTP = "http://localhost:" + FatUtils.LIBERTY_PORT_HTTP + "/unrestricted" + FatUtils.LARS_APPLICATION_ROOT;
+
+    /**
+     * HTTPS URL for the test instance where read operations are unrestricted.
+     * <p>
+     * Write operations are still restricted to users with the Admin role.
+     */
+    private static final String UNRESTRICTED_URL_HTTPS = "https://localhost:" + FatUtils.LIBERTY_PORT_HTTPS + "/unrestricted" + FatUtils.LARS_APPLICATION_ROOT;
 
     /**
      * The available roles that we expect test users to be mapped to by the test server
@@ -145,8 +158,10 @@ public class PermissionTest {
     public static Collection<Object[]> makeParameters() {
         Collection<Object[]> data = new ArrayList<>();
         for (User user : User.values()) {
-            data.add(new Object[] { RESTRICTED_URL, user.username, user.password, user.restrictedConfigRole, user + " - restricted" });
-            data.add(new Object[] { UNRESTRICTED_URL, user.username, user.password, user.unrestrictedConfigRole, user + " - unrestricted" });
+            data.add(new Object[] { RESTRICTED_URL_HTTP, user.username, user.password, user.restrictedConfigRole, user + " - restricted - http" });
+            data.add(new Object[] { UNRESTRICTED_URL_HTTP, user.username, user.password, user.unrestrictedConfigRole, user + " - unrestricted - http" });
+            data.add(new Object[] { RESTRICTED_URL_HTTPS, user.username, user.password, user.restrictedConfigRole, user + " - restricted - https" });
+            data.add(new Object[] { UNRESTRICTED_URL_HTTPS, user.username, user.password, user.unrestrictedConfigRole, user + " - unrestricted - https" });
         }
         System.out.println("sending data: " + data.size());
         return data;

--- a/test-utils/src/main/java/com/ibm/ws/lars/testutils/FatUtils.java
+++ b/test-utils/src/main/java/com/ibm/ws/lars/testutils/FatUtils.java
@@ -25,7 +25,8 @@ public class FatUtils {
     public static final String SCRIPT;
 
     public static final String DB_PORT;
-    public static final String LIBERTY_PORT;
+    public static final String LIBERTY_PORT_HTTP;
+    public static final String LIBERTY_PORT_HTTPS;
     public static final String TEST_DB_NAME;
     public static final String LARS_APPLICATION_ROOT;
 
@@ -46,13 +47,14 @@ public class FatUtils {
         }
 
         DB_PORT = defaultConfig.getProperty("testMongoPort");
-        LIBERTY_PORT = defaultConfig.getProperty("testLibertyPort");
+        LIBERTY_PORT_HTTP = defaultConfig.getProperty("testLibertyPortHTTP");
+        LIBERTY_PORT_HTTPS = defaultConfig.getProperty("testLibertyPortHTTPS");
         TEST_DB_NAME = defaultConfig.getProperty("testDbName");
         LARS_APPLICATION_ROOT = defaultConfig.getProperty("larsApplicationRoot");
 
     }
 
-    public static final String SERVER_URL = "http://localhost:" + LIBERTY_PORT + LARS_APPLICATION_ROOT;
+    public static final String SERVER_URL = "http://localhost:" + LIBERTY_PORT_HTTP + LARS_APPLICATION_ROOT;
 
     public static final String DEFAULT_HOST_AND_PORT = "localhost:" + DB_PORT;
 

--- a/test-utils/src/main/resources/config.properties
+++ b/test-utils/src/main/resources/config.properties
@@ -8,8 +8,12 @@
 
 # The port that mongod should use for test runs
 testMongoPort=27020
-# The port that liberty should use for test runs
-testLibertyPort=9085
+
+# The HTTP port that Liberty should use for test runs
+testLibertyPortHTTP=9085
+
+# The HTTPS port that Liberty should use for test runs
+testLibertyPortHTTPS=9448
 
 testDbName=larsDB
 


### PR DESCRIPTION
This change causes the API tests (but not the CLI tests) to run against both HTTP and the HTTPS endpoints. There should be no difference in behaviour between the two (and indeed there appears to be none).

The larsClient tests continue to run against only the HTTP endpoint because larsClient currently does not have any mechanism for easily accepting the testServer's self-signed certificate.
