### PR TITLE
Add hash creation code to LARS

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/massive/resources/MoreMassiveResourceTests.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/massive/resources/MoreMassiveResourceTests.java
@@ -19,16 +19,20 @@ package com.ibm.ws.massive.resources;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Locale;
 
 import org.junit.Test;
 
+import com.ibm.ws.massive.RepositoryException;
 import com.ibm.ws.massive.sa.client.model.Attachment;
 import com.ibm.ws.massive.sa.client.model.AttachmentSummary;
 
 public class MoreMassiveResourceTests {
+
+    private final static File resourceDir = new File("resources");
 
     @Test
     public void testLocaleProcessing() {
@@ -124,13 +128,34 @@ public class MoreMassiveResourceTests {
         }
     }
 
+    /**
+     * Test mainAttachementSHA256
+     *
+     * @throws IOException
+     * @throws RepositoryException
+     */
+    @Test
+    public void testMainAttachmentSHA256() throws IOException, RepositoryException {
+
+        File contentFile = new File(resourceDir, "crc1.txt");
+
+        String fileHash = HashUtils.getFileSHA256String(contentFile);
+
+        MassiveResource mr = new EsaResource(null);
+        mr.addContent(contentFile);
+
+        String contentHash = mr.getMainAttachmentSHA256();
+
+        assertEquals("Main attachment SHA256 hash should be the same as the hash of the file added", fileHash, contentHash);
+    }
+
     /*
      * attachement = get attachment by locale;
      * if (attachment != null)
      * return attachment;
      * targetLocale = new Locale(locale.getLanguage());
      * return get attachment by targetLocale;
-     *
+     * 
      * private Locale matchLocale (Locale matchThis) {
      * if (knownLocales.contains(matchThis)) {
      * return matchThis;

--- a/client-lib/src/main/java/com/ibm/ws/massive/resources/HashUtils.java
+++ b/client-lib/src/main/java/com/ibm/ws/massive/resources/HashUtils.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.massive.resources;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * HashUtils replaces the old MD5Utils to generate both the MD5 and SHA256 hash keys.
+ */
+public class HashUtils {
+
+    static final char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    static final String SHA256 = "SHA-256";
+    static final String MD5 = "MD5";
+
+    /**
+     * Calculate MD5 hash of a String
+     *
+     * @param str - the String to hash
+     * @return the MD5 hash value
+     */
+    public static String getMD5String(String str) {
+        MessageDigest messageDigest = getMessageDigest(MD5);
+        return getHashString(str, messageDigest);
+    }
+
+    /**
+     * Calculate MD5 hash of a File
+     *
+     * @param file - the File to hash
+     * @return the MD5 hash value
+     * @throws IOException
+     */
+    public static String getFileMD5String(File file) throws IOException {
+        MessageDigest messageDigest = getMessageDigest(MD5);
+        return getFileHashString(file, messageDigest);
+    }
+
+    /**
+     * Calculate SHA-256 hash of a String
+     *
+     * @param str - the String to hash
+     * @return the SHA-256 hash value
+     */
+    public static String getSHA256String(String str) {
+        MessageDigest messageDigest = getMessageDigest(SHA256);
+        return getHashString(str, messageDigest);
+    }
+
+    /**
+     * Calculate SHA-256 hash of a File
+     *
+     * @param file - the File to hash
+     * @return the SHA-256 hash value
+     * @throws IOException
+     */
+    public static String getFileSHA256String(File file) throws IOException {
+        MessageDigest messageDigest = getMessageDigest(SHA256);
+        return getFileHashString(file, messageDigest);
+    }
+
+    private static String getHashString(String str, MessageDigest messagedigest) {
+        messagedigest.update(str.getBytes());
+        return byteArrayToHexString(messagedigest.digest());
+    }
+
+    private static String getFileHashString(File file, MessageDigest messagedigest) throws IOException {
+        InputStream fis = null;
+        try {
+            fis = new FileInputStream(file);
+
+            byte[] buffer = new byte[1024];
+            int numRead = 0;
+            while ((numRead = fis.read(buffer)) > 0) {
+                messagedigest.update(buffer, 0, numRead);
+            }
+        } finally {
+            if (fis != null)
+                try {
+                    fis.close();
+                } catch (Exception e) {
+                }
+        }
+
+        return byteArrayToHexString(messagedigest.digest());
+    }
+
+    private static String byteArrayToHexString(byte[] byteArray) {
+
+        StringBuffer stringbuffer = new StringBuffer(2 * byteArray.length);
+        for (int i = 0; i < byteArray.length; i++) {
+            char upper = hexDigits[(byteArray[i] & 0xf0) >> 4];
+            char lower = hexDigits[byteArray[i] & 0xf];
+            stringbuffer.append(upper);
+            stringbuffer.append(lower);
+        }
+        return stringbuffer.toString();
+
+    }
+
+    /**
+     * this code replaces the creation of the message digest in a static code block
+     * as that was found to fail when multi threaded.
+     *
+     * @param digestType - MD5 or SHA-256
+     * @return the MessageDigest of the requested type
+     */
+    private static MessageDigest getMessageDigest(String digestType) {
+        MessageDigest messageDigest;
+        try {
+            messageDigest = MessageDigest.getInstance(digestType);
+        } catch (NoSuchAlgorithmException e) {
+            //should not happen
+            throw new RuntimeException(e);
+        }
+        return messageDigest;
+    }
+
+}

--- a/client-lib/src/main/java/com/ibm/ws/massive/sa/client/model/WlpInformation.java
+++ b/client-lib/src/main/java/com/ibm/ws/massive/sa/client/model/WlpInformation.java
@@ -62,6 +62,7 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
     private Collection<String> supersededBy;
     private Collection<String> supersededByOptional;
     private JavaSEVersionRequirements javaSEVersionRequirements;
+    private String mainAttachmentSHA256;
 
     public String getFeaturedWeight() {
         return featuredWeight;
@@ -372,6 +373,14 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
         this.mainAttachmentSize = mainAttachmentSize;
     }
 
+    public String getMainAttachmentSHA256() {
+        return mainAttachmentSHA256;
+    }
+
+    public void setMainAttachmentSHA256(String mainAttachmentSHA256) {
+        this.mainAttachmentSHA256 = mainAttachmentSHA256;
+    }
+
     public void addSupersededBy(String supersededByFeature) {
         if (this.supersededBy == null) {
             this.supersededBy = new HashSet<String>();
@@ -673,6 +682,14 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
                 return false;
             }
         } else if (!javaSEVersionRequirements.equals(other.javaSEVersionRequirements)) {
+            return false;
+        }
+
+        if (mainAttachmentSHA256 == null) {
+            if (other.mainAttachmentSHA256 != null) {
+                return false;
+            }
+        } else if (!mainAttachmentSHA256.equals(other.mainAttachmentSHA256)) {
             return false;
         }
 


### PR DESCRIPTION
Add code (and test) for creation of hash codes (MD5 and SHA256) and
modify the code so that an upload will store the SHA256 hash code in
uploaded resource.

Also reduce visibility on the setters for the attachment size and
attachment SHA256.
