### PR TITLE
Add a front page to LARS displaying the server status

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     sharedLibs group:'org.mongodb', name:'mongo-java-driver', version:mongodb_java_version
     providedCompile fileTree(dir: "${libertyRoot}/dev/api/spec", include: requiredSpecJars)
     providedCompile fileTree(dir: "${libertyRoot}/dev/api/third-party", include: 'com.ibm.websphere.appserver.thirdparty.jaxrs_*.jar')
+    providedCompile group:'com.google.code.findbugs', name:'annotations', version: '3.0.+'
 
     testCompile group:'junit', name:'junit', version:junit_version
     testCompile group:'org.hamcrest', name:'hamcrest-library', version:hamcrest_version

--- a/server/src/fat/java/com/ibm/ws/lars/rest/FrontPageTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/FrontPageTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.lars.rest;
+
+import static com.ibm.ws.lars.rest.AssetUtils.getTestAsset;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.ibm.ws.lars.rest.RepositoryContext.Protocol;
+import com.ibm.ws.lars.testutils.FatUtils;
+
+/**
+ * Tests for the LARS front page
+ */
+@RunWith(Parameterized.class)
+public class FrontPageTest {
+
+    @Rule
+    public final RepositoryContext repository;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] { { Protocol.HTTP, "http://localhost:" + FatUtils.LIBERTY_PORT_HTTP },
+                                             { Protocol.HTTPS, "https://localhost:" + FatUtils.LIBERTY_PORT_HTTPS } });
+    }
+
+    private final String baseUrl;
+
+    public FrontPageTest(Protocol protocol, String url) {
+        this.repository = RepositoryContext.createAsAdmin(true, protocol);
+        this.baseUrl = url;
+    }
+
+    @Test
+    public void testFrontPage() throws Exception {
+        HttpGet req = new HttpGet(baseUrl + "/");
+        String text = repository.doRequest(req, 200);
+        assertThat(text, containsString("The repository is running with 0 assets"));
+    }
+
+    @Test
+    public void testCorrectCount() throws Exception {
+        repository.addAssetNoAttachments(getTestAsset());
+        repository.addAssetNoAttachments(getTestAsset());
+        HttpGet req = new HttpGet(baseUrl + "/");
+        String text = repository.doRequest(req, 200);
+        assertThat(text, containsString("The repository is running with 2 assets"));
+    }
+
+}

--- a/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 import javax.ws.rs.core.UriInfo;
 
 import com.ibm.ws.lars.rest.exceptions.AssetPersistenceException;
@@ -50,7 +50,7 @@ import com.ibm.ws.lars.rest.model.RepositoryResourceLifecycleException;
  * -- time stamp updates<br>
  * -- partial updates (allowed or not??)
  */
-@Singleton
+@ApplicationScoped
 public class AssetServiceLayer {
 
     @Inject
@@ -389,7 +389,7 @@ public class AssetServiceLayer {
             throw new AssertionError("This should never happen.", e);
         }
 
-        String url = configuration.getURLBase(uriInfo) + "ma/v1/assets/" + attachment.getAssetId() + "/attachments/" + attachment.get_id() + "/" + encodedName;
+        String url = configuration.getRestBaseUri(uriInfo) + "assets/" + attachment.getAssetId() + "/attachments/" + attachment.get_id() + "/" + encodedName;
         attachment.setUrl(url);
     }
 

--- a/server/src/main/java/com/ibm/ws/lars/rest/Configuration.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/Configuration.java
@@ -32,7 +32,8 @@ public class Configuration {
     public Configuration() {
         String urlBase = null;
         try {
-            urlBase = (String) new InitialContext().lookup("lars/URLBase");
+            String configString = (String) new InitialContext().lookup("lars/URLBase");
+            urlBase = computeRestBaseUri(configString);
         } catch (NamingException e) {
             // lars/URLBase setting is optional
         }
@@ -40,11 +41,44 @@ public class Configuration {
         this.urlBase = urlBase;
     }
 
-    public String getURLBase(UriInfo uriInfo) {
+    /**
+     * Returns the base URL of the REST application
+     * <p>
+     * This method should be used to compute any absolute URLs to resources within the REST
+     * application.
+     * <p>
+     * This will be the same as uriInfo.getBaseUri, unless the user has configured a different URL.
+     *
+     * @param uriInfo the UriInfo to use to compute the base URL if the user has not overridden it
+     * @return the base URL of the REST application
+     */
+    public String getRestBaseUri(UriInfo uriInfo) {
         if (urlBase != null) {
             return urlBase;
         } else {
             return uriInfo.getBaseUri().toString();
         }
+    }
+
+    /**
+     * Given a URLBase that the user has provided, compute the corresponding BaseUri for the JAX-RS
+     * application.
+     * <p>
+     * This is needed to maintain the same configuration behaviour after we moved the root of the
+     * rest application.
+     * <p>
+     * If the user configures http://example.org/wibble, this method should return
+     * http://example.org/wibble/ma/v1/
+     *
+     * @param configString the user-provided URLBase string
+     * @return the base URL of the REST application
+     */
+    private static String computeRestBaseUri(String configString) {
+        StringBuilder b = new StringBuilder(configString);
+        if (!configString.endsWith("/")) {
+            b.append("/");
+        }
+        b.append("ma/v1/");
+        return b.toString();
     }
 }

--- a/server/src/main/java/com/ibm/ws/lars/rest/FrontPage.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/FrontPage.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.lars.rest;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * This front page exists as a simple IVT and to ensure there is a valid page at the server root to
+ * help monitoring tools.
+ */
+@SuppressWarnings("serial")
+@WebServlet("")
+public class FrontPage extends HttpServlet {
+
+    @Inject
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "CDI normal scoped injected field")
+    private AssetServiceLayer serviceLayer;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType(MediaType.TEXT_HTML);
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        int count = serviceLayer.countAllAssets(Collections.<String, List<Condition>> emptyMap(), null);
+
+        PrintWriter out = resp.getWriter();
+        out.println("<!DOCTYPE html>");
+        out.println("<html>");
+        out.println("<head><title>LARS is running</title></head>");
+        out.println("<body>");
+        out.println("<h1>LARS is running</h1>");
+        out.println("<p>The repository is running with " + count + " assets</p>");
+        out.println("</body>");
+        out.println("</html>");
+    }
+
+}

--- a/server/src/main/java/com/ibm/ws/lars/rest/PersistenceBean.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/PersistenceBean.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
-import javax.inject.Singleton;
+import javax.enterprise.context.ApplicationScoped;
 
 import org.bson.types.ObjectId;
 
@@ -65,7 +65,7 @@ import com.mongodb.gridfs.GridFSInputFile;
  * interface a bit nicer.
  *
  */
-@Singleton
+@ApplicationScoped
 public class PersistenceBean implements Persistor {
 
     private static final Logger logger = Logger.getLogger(PersistenceBean.class.getCanonicalName());

--- a/server/src/main/java/com/ibm/ws/lars/rest/RESTApplication.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/RESTApplication.java
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-@ApplicationPath("/")
+@ApplicationPath("/ma/v1")
 public class RESTApplication extends Application {
 
     @Inject

--- a/server/src/main/java/com/ibm/ws/lars/rest/RepositoryRESTResource.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/RepositoryRESTResource.java
@@ -81,7 +81,7 @@ import com.ibm.ws.lars.rest.model.RepositoryResourceLifecycleException;
  * security constraint in the web.xml which ensures that the user at least has the User or
  * Administrator role.
  */
-@Path("/ma/v1")
+@Path("/")
 @PermitAll
 public class RepositoryRESTResource {
 

--- a/server/src/test/java/com/ibm/ws/lars/rest/AssetServiceLayerTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/AssetServiceLayerTest.java
@@ -87,7 +87,7 @@ public class AssetServiceLayerTest {
         AssetServiceLayerInjection.setPersistenceBean(service, memoryPersistor);
         AssetServiceLayerInjection.setPrincipal(service, testPrincipal);
 
-        dummyUriInfo = new DummyUriInfo(new URI("http://localhost:9080/"));
+        dummyUriInfo = new DummyUriInfo(new URI("http://localhost:9080/ma/v1/"));
 
     }
 

--- a/server/src/test/java/com/ibm/ws/lars/rest/ConfigurationTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/ConfigurationTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.lars.rest;
+
+import static mockit.Deencapsulation.invoke;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link Configuration} class
+ */
+public class ConfigurationTest {
+
+    @Test
+    public void testComputeRestAppURLBase() {
+        String methodName = "computeRestBaseUri";
+        assertEquals("http://example.org/ma/v1/", invoke(Configuration.class, methodName, "http://example.org"));
+        assertEquals("http://example.org/ma/v1/", invoke(Configuration.class, methodName, "http://example.org/"));
+        assertEquals("http://example.org/wibble/ma/v1/", invoke(Configuration.class, methodName, "http://example.org/wibble"));
+        assertEquals("http://example.org/wibble/ma/v1/", invoke(Configuration.class, methodName, "http://example.org/wibble/"));
+    }
+
+}

--- a/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
@@ -60,7 +60,7 @@ public class RepositoryRESTResourceLoggingTest {
 
     @Before
     public void setUp() throws URISyntaxException {
-        dummyUriInfo = new DummyUriInfo(new URI("http://localhost:9080/"));
+        dummyUriInfo = new DummyUriInfo(new URI("http://localhost:9080/ma/v1/"));
     }
 
     @Test


### PR DESCRIPTION
Add a new simple servlet which displays a welcome page with the number
of assets in the server. This serves as a simple IVT and also allows
monitoring tools to work in the default configuration where they attempt
to retrieve the application root.

Adding the new servlet required moving the root of the JAX-RS
application from '/' to '/ma/v1' which resulted in some additional code
changes.

As a nice side-effect, I also made the BaseURL configuration a little
more friendly so that it will work whether or not it ends with a slash.

Also changed AssetServiceLayer from `Singleton` to `ApplicationScoped`. Singleton is not a CDI scope, so presumably AssetServiceLayer was being injected as a dependant bean which is not what we want, especially if anyone actually tries to Serialize the FrontPageServlet.
