### PR TITLE
Switch from JSON4J to JSONP for JSON Processing

### DIFF
--- a/LARS-1.1_versions.gradle
+++ b/LARS-1.1_versions.gradle
@@ -1,0 +1,26 @@
+/*
+ * The purpose of this file is to provide fixed versions of some
+ * these version run the gradle build with:
+ * 
+ *   -PversionFile=LARS-1.1_versions.gradle
+ */
+
+ext {
+	// Packaged runtime dependencies
+	// Fixed versions for the LARS 1.1 release
+	aries_util_version = "1.1.0"
+	osgi_core_version = "5.0.0"
+	jackson_version="2.4.4"
+	javax_json_version="1.0"
+	glassfish_json_version="1.0.4"
+	mongodb_java_version="2.11.1"
+
+	// Test/compile time only dependencies
+	// Fixed at 1.15 as 1.16beta was getting picked up, which had a bug in it.	
+	jmockit_version="1.15"
+	hamcrest_version="1.+"
+	junit_version="4.+"
+	httpclient_version="4.3.+"
+	httpmime_version="4.3.+"
+	wlp_ant_tasks_version="1.0"
+}

--- a/LARS_versions.gradle
+++ b/LARS_versions.gradle
@@ -3,7 +3,8 @@ ext {
 	aries_util_version = "1.1.+"
 	osgi_core_version = "5.0.+"
 	jackson_version="2.2.+"
-	wink_json4j_version="1.4"
+	javax_json_version="1.0"
+	glassfish_json_version="1.0.+"
 	mongodb_java_version="2.11.1"
 
 	// Test/compile time only dependencies

--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
@@ -24,12 +24,15 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
-import org.apache.wink.json4j.JSON;
-import org.apache.wink.json4j.JSONObject;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -430,12 +433,12 @@ public class DataModelSerializerTest {
         wlpInformation.setVisibility(Visibility.INSTALL);
         asset.setWlpInformation(wlpInformation);
         String json = DataModelSerializer.serializeAsString(asset);
-        JSONObject jsonObject = (JSONObject) JSON.parse(json);
+        JsonObject jsonObject = parseStringToJson(json);
         assertTrue("There should be a wlpInformation2 field", jsonObject.containsKey("wlpInformation2"));
-        JSONObject wlpInformation1 = (JSONObject) jsonObject.get("wlpInformation");
+        JsonObject wlpInformation1 = jsonObject.getJsonObject("wlpInformation");
         assertFalse("The first wlpinformation shouldn't contain the visibility: " + wlpInformation1, wlpInformation1.containsKey("visibility"));
-        JSONObject wlpInformation2 = (JSONObject) jsonObject.get("wlpInformation2");
-        assertEquals("The incompatible field should be stored in wlpInformation2", Visibility.INSTALL.toString(), wlpInformation2.get("visibility"));
+        JsonObject wlpInformation2 = jsonObject.getJsonObject("wlpInformation2");
+        assertEquals("The incompatible field should be stored in wlpInformation2", Visibility.INSTALL.toString(), wlpInformation2.getString("visibility"));
         Asset reReadAsset = DataModelSerializer.deserializeObject(new ByteArrayInputStream(json.getBytes()), Asset.class);
         assertEquals("The read in wlp inforamtion should say it has a visiblity of installer", Visibility.INSTALL, reReadAsset.getWlpInformation().getVisibility());
     }
@@ -449,13 +452,13 @@ public class DataModelSerializerTest {
         wlpInformation.setVisibility(Visibility.INSTALL);
         asset.setWlpInformation(wlpInformation);
         String json = DataModelSerializer.serializeAsString(asset);
-        JSONObject jsonObject = (JSONObject) JSON.parse(json);
+        JsonObject jsonObject = parseStringToJson(json);
         assertTrue("There should be a wlpInformation2 field", jsonObject.containsKey("wlpInformation2"));
-        JSONObject wlpInformation1 = (JSONObject) jsonObject.get("wlpInformation");
+        JsonObject wlpInformation1 = jsonObject.getJsonObject("wlpInformation");
         assertFalse("The first wlpinformation shouldn't contain the visibility: " + wlpInformation1, wlpInformation1.containsKey("visibility"));
-        assertEquals("The first wlpinformation should contain the applies to: " + wlpInformation1, "wibble", wlpInformation1.get("appliesTo"));
-        JSONObject wlpInformation2 = (JSONObject) jsonObject.get("wlpInformation2");
-        assertEquals("The incompatible field should be stored in wlpInformation2", Visibility.INSTALL.toString(), wlpInformation2.get("visibility"));
+        assertEquals("The first wlpinformation should contain the applies to: " + wlpInformation1, "wibble", wlpInformation1.getString("appliesTo"));
+        JsonObject wlpInformation2 = jsonObject.getJsonObject("wlpInformation2");
+        assertEquals("The incompatible field should be stored in wlpInformation2", Visibility.INSTALL.toString(), wlpInformation2.getString("visibility"));
         Asset reReadAsset = DataModelSerializer.deserializeObject(new ByteArrayInputStream(json.getBytes()), Asset.class);
         assertEquals("The read in wlp inforamtion should say it has a visiblity of installer", Visibility.INSTALL, reReadAsset.getWlpInformation().getVisibility());
         assertEquals("The read in wlp inforamtion should say it has the applies to set", "wibble", reReadAsset.getWlpInformation().getAppliesTo());
@@ -469,11 +472,19 @@ public class DataModelSerializerTest {
         wlpInformation.setVisibility(Visibility.PUBLIC);
         asset.setWlpInformation(wlpInformation);
         String json = DataModelSerializer.serializeAsString(asset);
-        JSONObject jsonObject = (JSONObject) JSON.parse(json);
+        JsonObject jsonObject = parseStringToJson(json);
         assertFalse("There shouldn't be a wlpInformation2 field", jsonObject.containsKey("wlpInformation2"));
-        JSONObject wlpInformation1 = (JSONObject) jsonObject.get("wlpInformation");
-        assertEquals("The first wlpinformation should contain the visibility: " + wlpInformation1, Visibility.PUBLIC.toString(), wlpInformation1.get("visibility"));
+        JsonObject wlpInformation1 = jsonObject.getJsonObject("wlpInformation");
+        assertEquals("The first wlpinformation should contain the visibility: " + wlpInformation1, Visibility.PUBLIC.toString(), wlpInformation1.getString("visibility"));
         Asset reReadAsset = DataModelSerializer.deserializeObject(new ByteArrayInputStream(json.getBytes()), Asset.class);
         assertEquals("The read in wlp inforamtion should say it has a visiblity of installer", Visibility.PUBLIC, reReadAsset.getWlpInformation().getVisibility());
+    }
+
+    private JsonObject parseStringToJson(String string) {
+        StringReader reader = new StringReader(string);
+        JsonReader jsonReader = Json.createReader(reader);
+        JsonObject parsedObject = jsonReader.readObject();
+        jsonReader.close();
+        return parsedObject;
     }
 }

--- a/client-lib/build.gradle
+++ b/client-lib/build.gradle
@@ -20,7 +20,8 @@ apply plugin: 'eclipse'
 dependencies {
     compile group:'org.apache.aries', name:'org.apache.aries.util', version:aries_util_version
     compile group:'org.osgi', name:'org.osgi.core', version:osgi_core_version
-    compile group:'org.apache.wink', name:'wink-json4j', version:wink_json4j_version
+    compile group:'javax.json', name:'javax.json-api', version:javax_json_version
+    runtime group:'org.glassfish', name:'javax.json', version:glassfish_json_version
 }
 
 task srcJar(type: Jar) {

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/RestClient.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/RestClient.java
@@ -32,6 +32,7 @@ import java.net.Proxy;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -42,14 +43,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.wink.json4j.JSONException;
-import org.apache.wink.json4j.JSONObject;
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonString;
 
 import com.ibm.ws.repository.common.enums.AttachmentLinkType;
 import com.ibm.ws.repository.common.enums.AttachmentType;
 import com.ibm.ws.repository.common.enums.FilterableAttribute;
-import com.ibm.ws.repository.common.enums.StateAction;
 import com.ibm.ws.repository.common.enums.ResourceType;
+import com.ibm.ws.repository.common.enums.StateAction;
 import com.ibm.ws.repository.transport.exceptions.BadVersionException;
 import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
 import com.ibm.ws.repository.transport.model.Asset;
@@ -964,15 +968,18 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
             return null;
         }
         try {
-            // Just use JSONObject parse directly instead of Wibblifier as we only want one attribute
-            JSONObject json = new JSONObject(errorObject);
-            Object errorMessage = json.opt("message");
-            if (errorMessage != null && errorMessage instanceof String && !((String) errorMessage).isEmpty()) {
-                return (String) errorMessage;
+            // Just use JsonObject parse directly instead of Wibblifier as we only want one attribute
+            InputStream inputStream = new ByteArrayInputStream(errorObject.getBytes(StandardCharsets.UTF_8));
+            JsonReader jsonReader = Json.createReader(inputStream);
+            JsonObject parsedObject = jsonReader.readObject();
+            jsonReader.close();
+            Object errorMessage = parsedObject.get("message");
+            if (errorMessage != null && errorMessage instanceof JsonString && !((JsonString) errorMessage).getString().isEmpty()) {
+                return ((JsonString) errorMessage).getString();
             } else {
                 return errorObject;
             }
-        } catch (JSONException e) {
+        } catch (JsonException e) {
             return errorObject;
         }
     }


### PR DESCRIPTION
Replace the Apache Wink JSON4J implementation with the Glassfish
javax.json implementation of JSONP. This required a number of changes to
the DataModelSerializer to use JSONP.
