### PR TITLE
Fix NPE and file closure in ZipClient

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/InvalidDirectoryClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/InvalidDirectoryClientTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.repository.transport.client.test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.ibm.ws.repository.transport.client.AbstractFileClient;
+import com.ibm.ws.repository.transport.client.DirectoryClient;
+import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
+
+public class InvalidDirectoryClientTest {
+
+    private final static File resourceDir = new File("resources");
+
+    @Test
+    public void testRepositoryStatusNoDirFound() throws Exception {
+        AbstractFileClient noDirClient = new DirectoryClient(new File("doesnotexist"));
+        try {
+            noDirClient.checkRepositoryStatus();
+            fail("An exception should have been thrown as the repo should not be reachable");
+        } catch (FileNotFoundException e) {
+            // We should get a FileNotFoundException from checkRepositoryStatus, any other exception should be
+            // allowed to propagate back up to cause the test to fail
+        }
+    }
+
+    @Test
+    public void testRepositoryStatusRootIsAFileNotADir() throws IOException, RequestFailureException {
+        AbstractFileClient invalidFile = new DirectoryClient(new File(resourceDir, "TestAttachment.txt"));
+        try {
+            invalidFile.checkRepositoryStatus();
+            fail("An exception should have been thrown as the repo should not be reachable");
+        } catch (IOException e) {
+            assertTrue("Wrong exception messages,  expected \"is not a directory\" but got \"" + e.getMessage() + "\"",
+                       e.getMessage().contains("is not a directory"));
+        }
+    }
+
+}

--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/InvalidZipClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/InvalidZipClientTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.repository.transport.client.test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.ibm.ws.repository.transport.client.AbstractFileClient;
+import com.ibm.ws.repository.transport.client.ZipClient;
+import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
+
+public class InvalidZipClientTest {
+
+    private final static File resourceDir = new File("resources");
+
+    @Test
+    public void testRepositoryStatusNoZipFound() throws Exception {
+        AbstractFileClient noZipClient = new ZipClient(new File("doesnotexist.zip"));
+        try {
+            noZipClient.checkRepositoryStatus();
+            fail("An exception should have been thrown as the repo should not be reachable");
+        } catch (FileNotFoundException e) {
+            // We should get a FileNotFoundException from checkRepositoryStatus, any other exception should be
+            // allowed to propagate back up to cause the test to fail
+        }
+    }
+
+    @Test
+    public void testRepositoryStatusInvalidZipFile() throws IOException, RequestFailureException {
+        AbstractFileClient invalidFile = new ZipClient(new File(resourceDir, "TestAttachment.txt"));
+        try {
+            invalidFile.checkRepositoryStatus();
+            fail("An exception should have been thrown as the repo should not be reachable");
+        } catch (IOException e) {
+            assertTrue("Wrong exception messages,  expected \"error in opening zip file\" but got \"" + e.getMessage() + "\"",
+                       e.getMessage().contains("error in opening zip file"));
+        }
+    }
+}

--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RepositoryClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RepositoryClientTest.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.json.stream.JsonGenerationException;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1479,6 +1481,18 @@ public class RepositoryClientTest {
                 fail("Unexpected asset found: " + asset);
             }
         }
+    }
+
+    @Test
+    public void testRepositoryStatusPass() throws Exception {
+
+        // create and write an asset to the repository before the check as the file will have been deleted
+        Asset asset1 = createTestAsset();
+        asset1.setType(ResourceType.FEATURE);
+        asset1.setDescription("keyword1");
+        asset1 = _writeableClient.addAsset(asset1);
+
+        _client.checkRepositoryStatus();
     }
 
     protected static Attachment addAttachment(String id, final String name,

--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RestClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RestClientTest.java
@@ -57,6 +57,7 @@ import com.ibm.ws.repository.common.enums.State;
 import com.ibm.ws.repository.common.enums.StateAction;
 import com.ibm.ws.repository.common.enums.Visibility;
 import com.ibm.ws.repository.connections.RestRepositoryConnection;
+import com.ibm.ws.repository.transport.client.ClientLoginInfo;
 import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
 import com.ibm.ws.repository.transport.client.RepositoryWriteableClient;
 import com.ibm.ws.repository.transport.client.RestClient;
@@ -73,7 +74,6 @@ import com.ibm.ws.repository.transport.model.AttachmentSummary;
 @RunWith(Parameterized.class)
 public class RestClientTest {
 
-    protected RestRepositoryConnection _loginInfoEntry;
     private static final Logger logger = Logger.getLogger(RestClientTest.class.getName());
     private static final File resourcesDir = new File("resources");
 
@@ -461,6 +461,21 @@ public class RestClientTest {
             fail("Should not be able to filter on private and install visibilities at the same time");
         } catch (IllegalArgumentException e) {
 
+        }
+    }
+
+    @Test
+    public void testRepositoryStatusNoRepoFound() throws IOException, RequestFailureException {
+
+        RestRepositoryConnection connection = (RestRepositoryConnection) fixture.getAdminConnection();
+        String realLocation = connection.getRepositoryUrl();
+        String invalidUrl = realLocation.substring(0, realLocation.indexOf("/ma")) + "/invalid";
+        RestClient notFound = new RestClient(new ClientLoginInfo("user", "password", "12345", invalidUrl));
+        try {
+            notFound.checkRepositoryStatus();
+            fail("An exception should have been thrown as the repo should not be reachable");
+        } catch (RequestFailureException e) {
+            // Expect a request failure exception
         }
     }
 

--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/connections/test/RepositoryConnectionTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/connections/test/RepositoryConnectionTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import com.ibm.ws.repository.connections.DirectoryRepositoryConnection;
 import com.ibm.ws.repository.connections.RestRepositoryConnection;
+import com.ibm.ws.repository.connections.ZipRepositoryConnection;
 import com.ibm.ws.repository.resources.internal.RepositoryResourceImpl;
 import com.ibm.ws.repository.resources.internal.SampleResourceImpl;
 
@@ -48,5 +49,14 @@ public class RepositoryConnectionTest {
         RepositoryResourceImpl mr = new SampleResourceImpl(dirCon);
         assertEquals("The repo url in the resource is not the one we set",
                      root.getAbsolutePath(), mr.getRepositoryConnection().getRepositoryLocation());
+    }
+
+    @Test
+    public void testZipRepoLocation() {
+        File zip = new File("repo.zip");
+        ZipRepositoryConnection zipCon = new ZipRepositoryConnection(zip);
+        RepositoryResourceImpl mr = new SampleResourceImpl(zipCon);
+        assertEquals("The repo url in the resource is not the one we set",
+                     zip.getAbsolutePath(), mr.getRepositoryConnection().getRepositoryLocation());
     }
 }

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/ZipClient.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/ZipClient.java
@@ -46,7 +46,7 @@ public class ZipClient extends AbstractFileClient {
 
     /**
      * Create a zip client which points to the specified zip file
-     * 
+     *
      * @param zip The zip file the client should read from
      */
     public ZipClient(File zip) {
@@ -61,16 +61,20 @@ public class ZipClient extends AbstractFileClient {
 
     /**
      * Checks the repository availability
-     * 
+     *
      * @return This will return void if all is ok but will throw an exception if
      *         there are any problems
      * @throws FileNotFoundException
      */
     @Override
     public void checkRepositoryStatus() throws IOException {
-        if (!exists(null)) {
+        if (!DirectoryUtils.exists(_zip)) {
             throw new FileNotFoundException("Could not find " + _zip);
         }
+        // This will throw an exception if the file is not a zip
+        ZipFile zip = DirectoryUtils.createZipFile(_zip);
+        // if the creation of the zip file is successful ensure it is closed to release the lock
+        zip.close();
     }
 
     /**
@@ -279,7 +283,7 @@ public class ZipClient extends AbstractFileClient {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @throws BadVersionException
      * @throws IOException
      */
@@ -335,7 +339,7 @@ public class ZipClient extends AbstractFileClient {
                 ZipEntry ze = zis.getNextEntry();
                 while (ze != null) {
                     if (ze.isDirectory()) {
-                        //do nothing 
+                        //do nothing
                     } else {
                         if ((liLocation != null && ze.getName().startsWith(liLocation)) ||
                             (laLocation != null && ze.getName().startsWith(laLocation))) {
@@ -368,7 +372,7 @@ public class ZipClient extends AbstractFileClient {
 
     /**
      * Gets the manifest for the specified asset
-     * 
+     *
      * @param assetId
      * @return
      * @throws IOException
@@ -384,7 +388,7 @@ public class ZipClient extends AbstractFileClient {
 
     /**
      * Gets the manifest file from an ESA
-     * 
+     *
      * @param assetId
      * @return
      * @throws IOException
@@ -425,7 +429,7 @@ public class ZipClient extends AbstractFileClient {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @throws IOException
      */
     protected Manifest getJarManifest(String assetId) throws IOException {


### PR DESCRIPTION
Modify ZipClient.checkRepositoryStatus() to fix a reported NPE and also
to ensure that it closes the zip repository file.
