### PR TITLE
Fix appliesTo() and ApplicableToProduct

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,11 @@ if(hasProperty("java6Home")) {
 				jars.add(it.path)
 			}
 		}
+		new File(java_bin_dir).eachFileRecurse {
+            if (it.path =~/\.jar$/) {
+                jars.add(it.path)
+            }
+        }
 	} catch (FileNotFoundException e) {
 		// do nothing. The check below will fail the build
 	}

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/AdminScriptResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/AdminScriptResource.java
@@ -22,25 +22,18 @@ import java.util.Collection;
  * <p>
  * This interface allows read access to fields which are specific to admin scripts.
  */
-public interface AdminScriptResource extends RepositoryResource {
+public interface AdminScriptResource extends RepositoryResource, ApplicableToProduct {
 
     /**
      * Get the language that the script is written in
-     * 
+     *
      * @return the language the script is written in, or null if it has not been set
      */
     public String getScriptLanguage();
 
     /**
-     * Gets the appliesTo field associated with the resource
-     * 
-     * @return The appliesTo field associated with the resource, or null if it has not been set
-     */
-    public String getAppliesTo();
-
-    /**
      * Gets the list of required features for this admin script
-     * 
+     *
      * @return The list of required features for this admin script, or null if no features are required
      */
     public Collection<String> getRequireFeature();

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/ConfigSnippetResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/ConfigSnippetResource.java
@@ -22,11 +22,11 @@ import java.util.Collection;
  * <p>
  * This interface allows read access to fields which are specific to config snippets.
  */
-public interface ConfigSnippetResource extends RepositoryResource {
+public interface ConfigSnippetResource extends RepositoryResource, ApplicableToProduct {
 
     /**
      * Gets the list of required features for this config snippet
-     * 
+     *
      * @return The list of required features for this config snippet, or null if no features are required
      */
     public Collection<String> getRequireFeature();

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/EsaResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/EsaResource.java
@@ -25,7 +25,7 @@ import com.ibm.ws.repository.common.enums.Visibility;
  * <p>
  * This interface allows read access to fields which are specific to features.
  */
-public interface EsaResource extends RepositoryResource {
+public interface EsaResource extends RepositoryResource, ApplicableToProduct {
 
     /**
      * Gets the symbolic name of the feature
@@ -61,13 +61,6 @@ public interface EsaResource extends RepositoryResource {
      * @return The lower cased short name, or null if it has not been set
      */
     public String getLowerCaseShortName();
-
-    /**
-     * Gets the appliesTo field associated with the resource
-     *
-     * @return The appliesTo field associated with the resource, or null if it has not been set
-     */
-    public String getAppliesTo();
 
     /**
      * Returns the value of the ibmProvisionCapability field (from the

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/IfixResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/IfixResource.java
@@ -23,25 +23,18 @@ import java.util.Date;
  * <p>
  * This interface allows read access to fields which are specific to ifixes.
  */
-public interface IfixResource extends RepositoryResource {
+public interface IfixResource extends RepositoryResource, ApplicableToProduct {
 
     /**
      * Gets the list of APAR IDs which are provided in this ifix resource
-     * 
+     *
      * @return the list of APAR IDs, or null if no APAR IDs are provided
      */
     public Collection<String> getProvideFix();
 
     /**
-     * Gets the appliesTo field associated with the resource
-     * 
-     * @return The appliesTo field associated with the resource, or null if it has not been set
-     */
-    public String getAppliesTo();
-
-    /**
      * Gets the modified date of the most recently modified file to be replaced by the update
-     * 
+     *
      * @return the date, or null if it has not been set
      */
     public Date getDate();

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/ProductResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/ProductResource.java
@@ -24,13 +24,6 @@ import com.ibm.ws.repository.common.enums.ResourceType;
  * <p>
  * Products represented by this interface can either be of type {@link ResourceType#INSTALL} or {@link ResourceType#ADDON}.
  */
-public interface ProductResource extends ProductRelatedResource {
-
-    /**
-     * Gets the appliesTo field associated with the resource
-     * 
-     * @return The appliesTo field associated with the resource, or null if it has not been set
-     */
-    public String getAppliesTo();
+public interface ProductResource extends ProductRelatedResource, ApplicableToProduct {
 
 }

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/SampleResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/SampleResource.java
@@ -26,18 +26,11 @@ import com.ibm.ws.repository.common.enums.ResourceType;
  * <p>
  * Samples represented by this interface can either be of type {@link ResourceType#PRODUCTSAMPLE} or {@link ResourceType#OPENSOURCE}.
  */
-public interface SampleResource extends RepositoryResource {
-
-    /**
-     * Gets the appliesTo field associated with the resource
-     * 
-     * @return The appliesTo field associated with the resource, or null if it has not been set
-     */
-    public String getAppliesTo();
+public interface SampleResource extends RepositoryResource, ApplicableToProduct {
 
     /**
      * Gets the list of required features for this sample
-     * 
+     *
      * @return The list of required features for this sample, or null if it has not been set
      */
     public Collection<String> getRequireFeature();
@@ -46,7 +39,7 @@ public interface SampleResource extends RepositoryResource {
      * Gets the short name for this sample
      * <p>
      * The short name should be the name of the server included in the sample.
-     * 
+     *
      * @return The short name for this sample, or null if it has not been set
      */
     public String getShortName();

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/WritableResourceFactory.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/WritableResourceFactory.java
@@ -17,6 +17,7 @@ package com.ibm.ws.repository.resources.writeable;
 
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.connections.RepositoryConnection;
+import com.ibm.ws.repository.exceptions.RepositoryResourceCreationException;
 import com.ibm.ws.repository.resources.internal.AdminScriptResourceImpl;
 import com.ibm.ws.repository.resources.internal.ConfigSnippetResourceImpl;
 import com.ibm.ws.repository.resources.internal.EsaResourceImpl;
@@ -60,6 +61,29 @@ public class WritableResourceFactory {
 
     public static ToolResourceWritable createTool(RepositoryConnection repoConnection) {
         return new ToolResourceImpl(repoConnection);
+    }
+
+    public static RepositoryResourceWritable createResource(RepositoryConnection repoConnection, ResourceType type) throws RepositoryResourceCreationException {
+        switch (type) {
+            case ADDON:
+            case INSTALL:
+                return createProduct(repoConnection, type);
+            case ADMINSCRIPT:
+                return createAdminScript(repoConnection);
+            case CONFIGSNIPPET:
+                return createConfigSnippet(repoConnection);
+            case FEATURE:
+                return createEsa(repoConnection);
+            case IFIX:
+                return createIfix(repoConnection);
+            case OPENSOURCE:
+            case PRODUCTSAMPLE:
+                return createSample(repoConnection, type);
+            case TOOL:
+                return createTool(repoConnection);
+            default:
+                throw new RepositoryResourceCreationException("Can not create an asset of type " + type, null);
+        }
     }
 
 }


### PR DESCRIPTION
Interfaces for Resources that are applicable to a product should
implement ApplicableToProduct and should not define appliesTo (as this
is defined in ApplicableToProduct)
