### PR TITLE
Fix formatting of build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,10 +286,10 @@ if(hasProperty("java6Home")) {
 			}
 		}
 		new File(java_bin_dir).eachFileRecurse {
-            if (it.path =~/\.jar$/) {
-                jars.add(it.path)
-            }
-        }
+			if (it.path =~/\.jar$/) {
+				jars.add(it.path)
+			}
+		}
 	} catch (FileNotFoundException e) {
 		// do nothing. The check below will fail the build
 	}


### PR DESCRIPTION
build.gradle has a mix of space and tab formatting.  Last change
introduced space formatting in the middle of a tab formatted block.
