### PR TITLE
Update dependency versions for LARS 1.1 release

### DIFF
--- a/LARS-1.1_versions.gradle
+++ b/LARS-1.1_versions.gradle
@@ -8,12 +8,12 @@
 ext {
 	// Packaged runtime dependencies
 	// Fixed versions for the LARS 1.1 release
-	aries_util_version = "1.1.0"
-	osgi_core_version = "5.0.0"
-	jackson_version="2.4.4"
+	aries_util_version = "1.1.1"
+	osgi_core_version = "6.0.0"
+	jackson_version="2.5.1"
 	javax_json_version="1.0"
 	glassfish_json_version="1.0.4"
-	mongodb_java_version="2.11.1"
+	mongodb_java_version="2.13.0"
 
 	// Test/compile time only dependencies
 	// Fixed at 1.15 as 1.16beta was getting picked up, which had a bug in it.	

--- a/LARS_versions.gradle
+++ b/LARS_versions.gradle
@@ -1,11 +1,11 @@
 ext {
 	// Packaged runtime dependencies
 	aries_util_version = "1.1.+"
-	osgi_core_version = "5.0.+"
-	jackson_version="2.2.+"
+	osgi_core_version = "6.0.+"
+	jackson_version="2.5.+"
 	javax_json_version="1.0"
 	glassfish_json_version="1.0.+"
-	mongodb_java_version="2.11.1"
+	mongodb_java_version="2.13.0"
 
 	// Test/compile time only dependencies
 	// Fixed at 1.15 as 1.16beta was getting picked up, which had a bug in it.

--- a/server/config/baseUrlServer.xml
+++ b/server/config/baseUrlServer.xml
@@ -44,7 +44,7 @@ limitations under the License.
          same MongoDB driver classes.
       -->
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
-        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.11.1.jar"/>
+        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
 
     <httpEndpoint httpPort="@HTTP_PORT@" id="defaultHttpEndpoint"/>

--- a/server/config/bluemixServer.xml
+++ b/server/config/bluemixServer.xml
@@ -43,7 +43,7 @@ in the configDropins/overrides directory.
          same MongoDB driver classes.
       -->
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
-        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.11.1.jar"/>
+        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
 
     <!--  These will be overwritten by bluemix -->

--- a/server/config/server.xml
+++ b/server/config/server.xml
@@ -53,7 +53,7 @@ limitations under the License.
          same MongoDB driver classes.
       -->
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
-        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.11.1.jar"/>
+        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
 
     <!-- Use slightly safer write concern than the default -->

--- a/server/config/testServer.xml
+++ b/server/config/testServer.xml
@@ -44,7 +44,7 @@ limitations under the License.
          same MongoDB driver classes.
       -->
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
-        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.11.1.jar"/>
+        <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
 
     <httpEndpoint httpPort="@HTTP_PORT@" httpsPort="@HTTPS_PORT@" id="defaultHttpEndpoint"/>


### PR DESCRIPTION
The versions of the dependencies have been moved up to newer versions. The MongoDB Java Driver jar references in the server.xml templates have been updated to use the latest version.
