### PR TITLE
[BUG] Ensure that JSONP can parse nulls as null rather than "null"

### DIFF
--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
@@ -353,6 +353,27 @@ public class DataModelSerializerTest {
         }
     }
 
+    public static class NullFieldTest {
+        String nullField;
+
+        public String getNullField() {
+            return nullField;
+        }
+
+        public void setNullField(String nullField) {
+            this.nullField = nullField;
+        }
+    }
+
+    @Test
+    public void testDeserializeNull() throws Exception {
+
+        NullFieldTest nft = DataModelSerializer.deserializeObject(new ByteArrayInputStream("{ \"nullField\": null }".getBytes()),
+                                                                  NullFieldTest.class);
+        assertEquals("Null field was not set correctly during null test,",
+                     null, nft.getNullField());
+    }
+
     public static class LocaleTest {
         Locale locale;
 

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/DataModelSerializer.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/DataModelSerializer.java
@@ -482,7 +482,6 @@ public class DataModelSerializer {
      * @throws IOException
      * @throws BadVersionException
      */
-    @SuppressWarnings("unchecked")
     private static <T> T processJsonObjectBackIntoDataModelInstance(JsonObject json, Class<? extends T> typeOfObject, Verification verify) throws IOException, BadVersionException {
         Set<Map.Entry<String, JsonValue>> jsonSet = json.entrySet();
 
@@ -507,7 +506,7 @@ public class DataModelSerializer {
             String keyString = keyEntry.getKey();
             JsonValue value = keyEntry.getValue();
 
-            if (value == null)
+            if (value == null || value.getValueType().equals(ValueType.NULL))
                 continue;
 
             //When calling toString() on a JsonString the value is returned in quotation marks, so we need to call getString() on JsonString to avoid this


### PR DESCRIPTION
Change DataModelSerializer (and it's test) to handle a null field in the
database as a null rather than converting it to a string.
