### PR TITLE
Fix partial delivery of code to DataModelSerializerTest

### DIFF
--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
@@ -362,6 +362,15 @@ public class DataModelSerializerTest {
         List<String> stringList;
         List<Boolean> booleanList;
         List<Integer> integerList;
+        Integer integerField;
+
+        public Integer getIntegerField() {
+            return integerField;
+        }
+
+        public void setIntegerField(Integer integerField) {
+            this.integerField = integerField;
+        }
 
         public int getIntField() {
             return intField;


### PR DESCRIPTION
DataModelSerializerTest updated to re-include a change to the internal
DeserialisationHelperClass, the absence of which was causing a test
failure.
