### PR TITLE
IOExceptions on delete shouldn't be rethrown as ResourceExceptions

### DIFF
--- a/cli-client/src/main/java/com/ibm/ws/lars/upload/cli/Main.java
+++ b/cli-client/src/main/java/com/ibm/ws/lars/upload/cli/Main.java
@@ -487,7 +487,7 @@ public class Main {
 
             try {
                 toDelete.delete();
-            } catch (RepositoryResourceDeletionException e) {
+            } catch (RepositoryResourceDeletionException | RepositoryBackendException e) {
                 // This can be an IO issue, or a request fail. Request fail is either a server
                 // problem, or a non-existent asset. We've just checked that the asset exists, so
                 // non-existent asset seems unlikely, most likely a server problem. As the source exception

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/RepositoryResourceImpl.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/RepositoryResourceImpl.java
@@ -48,10 +48,10 @@ import com.ibm.ws.repository.common.enums.AttachmentType;
 import com.ibm.ws.repository.common.enums.DisplayPolicy;
 import com.ibm.ws.repository.common.enums.DownloadPolicy;
 import com.ibm.ws.repository.common.enums.LicenseType;
-import com.ibm.ws.repository.common.enums.State;
-import com.ibm.ws.repository.common.enums.StateAction;
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.common.enums.ResourceTypeLabel;
+import com.ibm.ws.repository.common.enums.State;
+import com.ibm.ws.repository.common.enums.StateAction;
 import com.ibm.ws.repository.common.enums.Visibility;
 import com.ibm.ws.repository.common.utils.internal.HashUtils;
 import com.ibm.ws.repository.connections.ProductDefinition;
@@ -72,6 +72,7 @@ import com.ibm.ws.repository.exceptions.RepositoryResourceLifecycleException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceUpdateException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceValidationException;
 import com.ibm.ws.repository.resources.AttachmentResource;
+import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.resources.internal.AppliesToProcessor.AppliesToEntry;
 import com.ibm.ws.repository.resources.writeable.AttachmentResourceWritable;
 import com.ibm.ws.repository.resources.writeable.RepositoryResourceWritable;
@@ -1263,11 +1264,11 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
 
     /** {@inheritDoc} */
     @Override
-    public void delete() throws RepositoryResourceDeletionException {
+    public void delete() throws RepositoryResourceDeletionException, RepositoryBackendIOException {
         try {
             getWritableClient().deleteAssetAndAttachments(_asset.get_id());
         } catch (IOException ioe) {
-            throw new RepositoryResourceDeletionException("Failed to delete resource", this.getId(), ioe);
+            throw new RepositoryBackendIOException("Failed to delete resource " + this.getId(), ioe, this.getRepositoryConnection());
         } catch (RequestFailureException e) {
             throw new RepositoryResourceDeletionException("Failed to delete resource", this.getId(), e);
         } catch (RepositoryOperationNotSupportedException e) {
@@ -1680,7 +1681,7 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
          *
          * @throws RepositoryResourceException
          */
-        public void deleteNow() throws RepositoryResourceDeletionException {
+        public void deleteNow() throws RepositoryResourceDeletionException, RepositoryBackendIOException {
             synchronized (RepositoryResourceImpl.this) {
                 try {
                     if (getId() != null) {
@@ -1691,7 +1692,8 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
                         _contentAttached = false;
                     }
                 } catch (IOException e) {
-                    throw new RepositoryResourceDeletionException("Failed to delete the attachment " + getId() + " in asset " + RepositoryResourceImpl.this.getId(), this.getId(), e);
+                    throw new RepositoryBackendIOException("Failed to delete the attachment " + getId() + " in asset " + RepositoryResourceImpl.this.getId(), e,
+                                    RepositoryResourceImpl.this.getRepositoryConnection());
                 } catch (RequestFailureException e) {
                     throw new RepositoryResourceDeletionException("Failed to delete the attachment " + getId() + " in asset " + RepositoryResourceImpl.this.getId(), this.getId(), e);
                 } catch (RepositoryOperationNotSupportedException rbnse) {

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/RepositoryResourceWritable.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/RepositoryResourceWritable.java
@@ -46,7 +46,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * By default this class uses a cached version of the resource which may have
      * stale data (including attachments), calling this method forces the class to grab a
      * new version of the resource from massive.
-     * 
+     *
      * @throws RepositoryBackendException
      */
     public void refreshFromMassive() throws RepositoryBackendException, RepositoryResourceException;
@@ -60,21 +60,21 @@ public interface RepositoryResourceWritable extends RepositoryResource {
 
     /**
      * Sets the human readable name of the resource
-     * 
+     *
      * @param name the human readable name of the resource
      */
     public void setName(String name);
 
     /**
      * Sets the provider name
-     * 
+     *
      * @param providerName the provider name
      */
     public void setProviderName(String providerName);
 
     /**
      * Sets the provider URL
-     * 
+     *
      * @param providerUrl
      */
     public void setProviderUrl(String providerUrl);
@@ -83,14 +83,14 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Sets the long description for the resource
      * <p>
      * This is used as the body text on the wasdev website and is in HTML format.
-     * 
+     *
      * @param desc a long HTML description of the resource
      */
     public void setDescription(String desc);
 
     /**
      * Sets the short description of the resource
-     * 
+     *
      * @param shortDescription The short description to use for the resource
      */
     public void setShortDescription(String shortDescription);
@@ -99,28 +99,28 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Gets the {@link State} of the resource.
      * <p>
      * The state cannot be set by other fields but may be updated by the upload strategy when calling {@link #uploadToMassive(UploadStrategy)}.
-     * 
+     *
      * @return the State of the resource
      */
     public State getState();
 
     /**
      * Sets the version of the resource.
-     * 
+     *
      * @param version the version of the resource
      */
     public void setVersion(String version);
 
     /**
      * Sets the download policy of the resource
-     * 
+     *
      * @param policy the download policy of the resource
      */
     public void setDownloadPolicy(DownloadPolicy policy);
 
     /**
      * Sets the {@link DisplayPolicy} to use
-     * 
+     *
      * @param policy the display policy
      */
     public void setDisplayPolicy(DisplayPolicy policy);
@@ -129,14 +129,14 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Sets the relative URL where this resource should appear if a website is used to display resources in the repository.
      * <p>
      * Generally this value is an easier to remember identifier for the resource that is more SEO friendly.
-     * 
+     *
      * @param vanityUrl a relative URL for this resource
      */
     public void setVanityURL(String vanityUrl);
 
     /**
      * Gets the relative URL where this resource should appear if a website is used to display resources in the repository.
-     * 
+     *
      * @return a relative URL for this resource
      */
     public String getVanityURL();
@@ -144,21 +144,21 @@ public interface RepositoryResourceWritable extends RepositoryResource {
     /**
      * Sets the featured weight. This is a String value although it will be a number from 1 to 9, with 9 being the highest weight.
      * Not having a value set means it is lower in priority than any that have a weight.
-     * 
+     *
      * @param featuredWeight
      */
     public void setFeaturedWeight(String featuredWeight);
 
     /**
      * Returns a collection of all of the minimum versions from this resource's applies to String.
-     * 
+     *
      * @return a collection of versions which may be empty but won't be <code>null</code>
      */
     public Collection<String> getAppliesToMinimumVersions();
 
     /**
      * (Re)calculate any fields that may be based on information within this resource.
-     * 
+     *
      * @param performEditionChecking whether to validate the product editions in the appliesTo field
      * @throws RepositoryResourceCreationException if the resource applies to an invalid edition and {@code performEditionChecking} is {@code true}
      */
@@ -168,7 +168,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Adds a main, or "content" attachment to the resource which will be stored in the repository. The filename is used as the name of the attachment.
      * <p>
      * This is equivalent to calling {@link #addContent(File, String) addContent(file, file.getName())}
-     * 
+     *
      * @param file the file to be added as the main attachment
      * @return the AttachmentResource representation of the supplied file
      * @throws RepositoryException if there is a problem adding the attachment
@@ -181,7 +181,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * There can be only one attachment of AttachmentType.CONTENT.
      * <p>
      * When the resource is uploaded, the attachment file will also be uploaded to the repository.
-     * 
+     *
      * @param file the file to be added as the main attachment
      * @param name the name of the attachment
      * @return the AttachmentResource representation of the supplied file
@@ -205,7 +205,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * <p>
      * The linkType describes how the file can be retrieved. For features, this should always be {@link AttachmentLinkType#DIRECT} so that the feature file can be downloaded by the
      * installer.
-     * 
+     *
      * @param file the file to be added as the main attachment. This file will be read but not uploaded
      * @param name the name of the attachment
      * @param url the URL where the attachment file can be downloaded
@@ -221,7 +221,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * This is equivalent to {@link #addAttachment(File, AttachmentType, String) addAttachment(file, attachmentType, file.getName()} <p>
      * <p>
      * In most cases, a more specific method should be used to add attachments (e.g. {@link #addContent(File)}, {@link #addLicense(File, Locale)}).
-     * 
+     *
      * @param file the file to add as an attachment
      * @param type the type of the attachment
      * @return the AttachmentResource representation of the supplied file
@@ -233,7 +233,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Adds the supplied attachment to the resource under the supplied name. The file will be uploaded to the repository when the resource is uploaded.
      * <p>
      * In most cases, a more specific method should be used to add attachments (e.g. {@link #addContent(File, String)}, {@link #addLicense(File, Locale)}).
-     * 
+     *
      * @param file The attachment to be added
      * @param name The name to use for the attachment
      *            a new attachment to be added
@@ -246,7 +246,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Adds the supplied attachment to the resource. A URL to the file will be stored in the repository but the file itself will never be uploaded.
      * <p>
      * Adds an attachment of the given type. The attachment is not stored in the repository as described for {@link #addContent(File, String, String, AttachmentLinkType)}.
-     * 
+     *
      * @param file the attachment file to add
      * @param type the type of the attachment
      * @param name the name of the attachment
@@ -260,7 +260,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
 
     /**
      * Adds a complete license file attachment to the resource
-     * 
+     *
      * @param license the license file
      * @param loc the locale of the license text
      * @throws RepositoryException if there is a problem adding the license
@@ -269,7 +269,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
 
     /**
      * Adds a license agreement file attachment to the resource
-     * 
+     *
      * @param license the license agreement file
      * @param loc the locale of the license agreement text
      * @throws RepositoryException if there is a problem adding the license agreement
@@ -278,7 +278,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
 
     /**
      * Adds a license information file attachment to the resource
-     * 
+     *
      * @param license the license information file
      * @param loc the locale of the license information text
      * @throws RepositoryException if there is a problem adding the license information
@@ -287,7 +287,7 @@ public interface RepositoryResourceWritable extends RepositoryResource {
 
     /**
      * Sets the license type of the resource
-     * 
+     *
      * @param lt the license type
      */
     public void setLicenseType(LicenseType lt);
@@ -296,14 +296,14 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Set the LicenseId.
      * <p>
      * Currently this is only set for features based on the Subsystem-License header
-     * 
+     *
      * @param lic the license id
      */
     public void setLicenseId(String lic);
 
     /**
      * Uploads the resource to the repository using the supplied strategy
-     * 
+     *
      * @param strategy the upload strategy to use
      * @throws RepositoryBackendException if there is a problem communicating with the remote repository
      * @throws RepositoryResourceException if there is another problem uploading the resource
@@ -314,16 +314,16 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * Deletes the resource and all the attachments
      * <p>
      * The caller should not make any changes to the object after calling this method
-     * 
+     *
      * @throws RepositoryResourceDeletionException if there is a problem deleting the resource
      */
-    public void delete() throws RepositoryResourceDeletionException;
+    public void delete() throws RepositoryBackendException, RepositoryResourceDeletionException;
 
     /**
      * Returns a URL which represent the URL that can be used to view the asset in Massive. This is more
      * for testing purposes, the assets can be access programatically via various methods on this class.
      * This is only used by the uploaders so is only for massive based repos
-     * 
+     *
      * @return String - the asset URL
      */
     public String getAssetURL();

--- a/upload-lib/src/main/java/com/ibm/ws/massive/esa/MassiveEsa.java
+++ b/upload-lib/src/main/java/com/ibm/ws/massive/esa/MassiveEsa.java
@@ -44,6 +44,7 @@ import com.ibm.ws.repository.common.enums.LicenseType;
 import com.ibm.ws.repository.common.enums.Visibility;
 import com.ibm.ws.repository.connections.RepositoryConnection;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
+import com.ibm.ws.repository.exceptions.RepositoryBackendException;
 import com.ibm.ws.repository.exceptions.RepositoryException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceCreationException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceException;
@@ -117,7 +118,7 @@ public class MassiveEsa extends MassiveUploader implements RepositoryUploader<Es
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.massive.upload.RepositoryUploader#canUploadFile(java.io.File)
      */
     @Override
@@ -127,7 +128,7 @@ public class MassiveEsa extends MassiveUploader implements RepositoryUploader<Es
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.massive.upload.RepositoryUploader#uploadFile(java.io.File,
      * com.ibm.ws.massive.resources.UploadStrategy)
      */
@@ -385,10 +386,12 @@ public class MassiveEsa extends MassiveUploader implements RepositoryUploader<Es
 
     /**
      * Utility method to delete all the features in MaaSive.
+     * 
+     * @throws RepositoryBackendException
      *
      * @throws IOException
      */
-    public void deleteAllFeatures() throws RepositoryResourceException {
+    public void deleteAllFeatures() throws RepositoryResourceException, RepositoryBackendException {
         Iterator<EsaResource> featureIterator = this.allFeatures
                 .values().iterator();
         while (featureIterator.hasNext()) {
@@ -538,7 +541,7 @@ public class MassiveEsa extends MassiveUploader implements RepositoryUploader<Es
 
         /*
          * (non-Javadoc)
-         * 
+         *
          * @see java.lang.Object#hashCode()
          */
         @Override
@@ -553,7 +556,7 @@ public class MassiveEsa extends MassiveUploader implements RepositoryUploader<Es
 
         /*
          * (non-Javadoc)
-         * 
+         *
          * @see java.lang.Object#equals(java.lang.Object)
          */
         @Override


### PR DESCRIPTION
A ResourceException indicates a badly formed resource, so if an
IOException comes back from the server, it should be rethrown as a
RepositoryBackendIOException instead of a
RepositoryResourceDeletionException
