### PR TITLE
[BUG] Empty filter sets should be ignored in getFilteredAssets

### DIFF
--- a/client-lib-tests/build.gradle
+++ b/client-lib-tests/build.gradle
@@ -22,6 +22,17 @@ apply plugin: 'eclipse'
 dependencies {
     testCompile project(':client-lib')
     testCompile project(':test-utils')
+    testCompile group:'org.jmockit', name:'jmockit', version:jmockit_version
+}
+// With out the exclude below, the jmockit classes are initialised during the fat test runs
+// for some not obvious reason. The test run then falls over with an 'AttachNotSupported'
+// exception. None of the fat tests use jmockit, so it's not obvious what's happening.
+// Excluding the jmockit jar seems to be the simplest solution.
+configurations.fatCompile.exclude group: 'org.jmockit', module: 'jmockit'
+
+test {
+    File jmockitJar = configurations.testCompile.find({it.name.startsWith("jmockit")})
+    jvmArgs "-javaagent:"+jmockitJar.getAbsolutePath()
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_6

--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/AbstractFileClientTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/AbstractFileClientTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.repository.transport.client.test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.ibm.ws.lars.testutils.clients.DirectoryWriteableClient;
+import com.ibm.ws.repository.common.enums.FilterableAttribute;
+import com.ibm.ws.repository.common.enums.ResourceType;
+import com.ibm.ws.repository.transport.client.DirectoryClient;
+import com.ibm.ws.repository.transport.exceptions.BadVersionException;
+import com.ibm.ws.repository.transport.exceptions.ClientFailureException;
+import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
+import com.ibm.ws.repository.transport.model.Asset;
+
+public class AbstractFileClientTest {
+
+    @Test
+    public void testEmptyFiltersAreIgnored() throws IOException, RequestFailureException, SecurityException, BadVersionException, ClientFailureException {
+
+        File repoDir = getTempDir();
+
+        Asset asset = new Asset();
+        asset.setName("a silly asset");
+        asset.setType(ResourceType.FEATURE);
+
+        DirectoryWriteableClient writeableClient = new DirectoryWriteableClient(repoDir);
+        writeableClient.addAsset(asset);
+
+        Map<FilterableAttribute, Collection<String>> filters =
+                        new HashMap<FilterableAttribute, Collection<String>>();
+        filters.put(FilterableAttribute.TYPE, Collections.singleton(ResourceType.FEATURE.getValue()));
+        filters.put(FilterableAttribute.LOWER_CASE_SHORT_NAME, Collections.<String> emptySet());
+
+        DirectoryClient client = new DirectoryClient(repoDir);
+        Collection<Asset> filtered = client.getFilteredAssets(filters);
+        assertThat("One asset should have been returned by the filtering operation", filtered, hasSize(1));
+        assertEquals("An asset with the wrong name came back", "a silly asset", filtered.iterator().next().getName());
+
+    }
+
+    public static File getTempDir() throws IOException {
+        File tmpRepoRoot = File.createTempFile("tempRepoDir", null);
+        tmpRepoRoot.delete();
+        File tmpRepoDir = new File(tmpRepoRoot.getPath());
+        if (!tmpRepoDir.mkdir()) {
+            throw new IOException("Couldn't create directory for temp repo directory: " + tmpRepoDir);
+        }
+        tmpRepoDir.deleteOnExit();
+        return tmpRepoDir;
+    }
+
+}

--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/RestClientUnitTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/RestClientUnitTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.repository.transport.client.test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import mockit.Deencapsulation;
+import mockit.Expectations;
+
+import org.junit.Test;
+
+import com.ibm.ws.repository.common.enums.FilterableAttribute;
+import com.ibm.ws.repository.common.enums.ResourceType;
+import com.ibm.ws.repository.transport.client.ClientLoginInfo;
+import com.ibm.ws.repository.transport.client.RestClient;
+import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
+
+public class RestClientUnitTest {
+
+    /**
+     * The test verifies that empty filters are ignored, i.e. they are not included in the query
+     * url passed to the repository.
+     *
+     */
+    @Test
+    public void testEmptyFiltersAreIgnored() throws IOException, RequestFailureException {
+
+        ClientLoginInfo info = new ClientLoginInfo("noone", "letmein", "123", "http://broken");
+
+        /*
+         * This is voodoo.... Doing this without a repository involves mocking the connection, but
+         * it turns out that mocking HttpURLConnection is really hard. Instead, partially mock the client
+         * object. The method to be tested (i.e. getFilteredAssets) is not mocked, but the private method
+         * which returns the HTTP connection is.
+         */
+        final RestClient client = new RestClient(info);
+        new Expectations(client) {
+            {
+                Deencapsulation.invoke(client, "createHttpURLConnectionToMassive", "/assets?type=com.ibm.websphere.Feature");
+                // now that the correct query string has been constructed, stop the test
+                // Otherwise the test will try to connect to a duff url
+                result = new NullPointerException("This might just work");
+            }
+
+        };
+
+        Map<FilterableAttribute, Collection<String>> filters = new HashMap<FilterableAttribute, Collection<String>>();
+        filters.put(FilterableAttribute.TYPE, Collections.singleton(ResourceType.FEATURE.getValue()));
+        filters.put(FilterableAttribute.LOWER_CASE_SHORT_NAME, Collections.<String> emptySet());
+
+        try {
+            client.getFilteredAssets(filters);
+        } catch (NullPointerException e) {
+            if (!e.getMessage().equals("This might just work")) {
+                throw e;
+            }
+        }
+
+    }
+
+}

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/AbstractFileClient.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/AbstractFileClient.java
@@ -108,7 +108,7 @@ public abstract class AbstractFileClient extends AbstractRepositoryClient implem
                 // List of values in the asset
                 Collection<String> assetValues = getValues(attrib, asset);
 
-                if (values != null) {
+                if (values != null && values.size() != 0) {
                     // Check each required value and see if the asset has it
                     for (String filterValue : values) {
                         // if we find a match stop checking this attribute and move to next attribute


### PR DESCRIPTION
The current implementation of AbstractFileClient.getFilteredAssets will
return an empty set (i.e. nothing will match) if any of the filter sets
contain no values. This doesn't match the behaviour of the REST client.
This fix will mean that empty filter sets are ignored, as per the REST
client
