### PR TITLE
Changes required to handle platform specific assets

### DIFF
--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/client/test/DataModelSerializerTest.java
@@ -279,16 +279,16 @@ public class DataModelSerializerTest {
             fail("Version 0.9 is too low: exception expected");
         } catch (BadVersionException bvx) {
             assertEquals("1.0", bvx.getMinVersion());
-            assertEquals("2.0", bvx.getMaxVersion());
+            assertEquals("3.0", bvx.getMaxVersion());
             assertEquals("0.9", bvx.getBadVersion());
         }
 
         try {
             test = DataModelSerializer.deserializeObject(
-                                                         new ByteArrayInputStream("{ \"wlpInformationVersion\":\"2.0\"}".getBytes()), WlpInformation.class);
-            fail("Version 2.0 is too high: exception expected");
+                                                         new ByteArrayInputStream("{ \"wlpInformationVersion\":\"3.0\"}".getBytes()), WlpInformation.class);
+            fail("Version 3.0 is too high: exception expected");
         } catch (BadVersionException bvx) {
-            assertEquals("2.0", bvx.getBadVersion());
+            assertEquals("3.0", bvx.getBadVersion());
         }
     }
 

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/ProductRelatedResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/ProductRelatedResource.java
@@ -17,6 +17,8 @@ package com.ibm.ws.repository.resources;
 
 import java.util.Collection;
 
+import org.osgi.resource.Requirement;
+
 /**
  * Represents a product-like (either a product or a tool) resource in the repository.
  * <p>
@@ -26,44 +28,58 @@ public interface ProductRelatedResource extends RepositoryResource {
 
     /**
      * Gets the productId for the resource.
-     * 
+     *
      * @return the product id, or null if it has not been set
      */
     public String getProductId();
 
     /**
      * Gets the edition of the product, if applicable.
-     * 
+     *
      * @return the edition of the product, or null if it is not set
      */
     public String getProductEdition();
 
     /**
      * Gets the install type of the product (e.g. "Archive")
-     * 
+     *
      * @return the install type, or null if it is not set
      */
     public String getProductInstallType();
 
     /**
      * Gets the version of the product
-     * 
+     *
      * @return the product version, or null if it is not set
      */
     public String getProductVersion();
 
     /**
      * Gets the features included in this product
-     * 
+     *
      * @return the features provided by this product, or null if not set
      */
     public Collection<String> getProvideFeature();
 
     /**
      * Gets the features that this product depends on
-     * 
+     *
      * @return the features required by this product, or null if not set
      */
     public Collection<String> getRequireFeature();
+
+    /**
+     * Gets the collection of OSGi requirements this product has
+     *
+     * @return the collection of OSGi requirements applicable to this product, or null if not set
+     */
+    public Collection<Requirement> getGenericRequirements();
+
+    /**
+     * Gets the version information for the Java packaged with this product
+     *
+     * @return The Java version information, or null if this product is not packaged with Java
+     */
+    public String getPackagedJava();
 
 }

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/RepositoryResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/RepositoryResource.java
@@ -29,6 +29,7 @@ import com.ibm.ws.repository.connections.RepositoryConnection;
 import com.ibm.ws.repository.exceptions.RepositoryBackendException;
 import com.ibm.ws.repository.exceptions.RepositoryException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceException;
+import com.ibm.ws.repository.transport.model.WlpInformation;
 
 /**
  * Represents a resource in a repository.
@@ -42,7 +43,7 @@ public interface RepositoryResource {
      * Gets the repository connection which this resource is associated with
      * <p>
      * This will only be null if the resource was not retrieved from a repository.
-     * 
+     *
      * @return the associated repository connection, or null if the resource is not associated with a repository
      */
     public RepositoryConnection getRepositoryConnection();
@@ -51,35 +52,35 @@ public interface RepositoryResource {
      * Gets the resource ID
      * <p>
      * This is an arbitrary string which uniquely identifies the resource within the repository. Resource IDs may change if the resource is updated in the repository.
-     * 
+     *
      * @return the resource ID, or null if the resource was not retrieved from a repository
      */
     public String getId();
 
     /**
      * Gets the human readable name of the resource
-     * 
+     *
      * @return the human readable name of the resource, or null if it is not set
      */
     public String getName();
 
     /**
      * Gets the provider name
-     * 
+     *
      * @return the provider name, or null if it is not set
      */
     public String getProviderName();
 
     /**
      * Gets the provider URL
-     * 
+     *
      * @return the provider URL
      */
     public String getProviderUrl();
 
     /**
      * Gets the type of this resource (Feature, Product etc.)
-     * 
+     *
      * @return the resource type, or null if it is not set
      */
     public ResourceType getType();
@@ -88,35 +89,35 @@ public interface RepositoryResource {
      * Gets the long description for the resource.
      * <p>
      * This is used as the body text on the wasdev website and is in HTML format.
-     * 
+     *
      * @return a long HTML description of the resource, or null if it is not set
      */
     public String getDescription();
 
     /**
      * Gets the version of the resource
-     * 
+     *
      * @return the version, or null if it is not set
      */
     public String getVersion();
 
     /**
      * Gets the size of the main attachment of the resource, if it has a main attachment.
-     * 
+     *
      * @return the size of the main attachment in bytes, or zero if there is no main attachment
      */
     public long getMainAttachmentSize();
 
     /**
      * Gets the SHA256 hash of the main attachment of the resource, if it has a main attachment.
-     * 
+     *
      * @return the SHA256 hash of the main attachment, or null if there is no main attachment
      */
     public String getMainAttachmentSHA256();
 
     /**
      * Gets the download policy of the resource.
-     * 
+     *
      * @return the download policy of the resource
      */
     public DownloadPolicy getDownloadPolicy();
@@ -124,7 +125,7 @@ public interface RepositoryResource {
     /**
      * Gets the featured weight. This is a String value although it will be a number from 1 to 9, with 9 being the highest weight.
      * Not having a value set means it is lower in priority than any that have a weight.
-     * 
+     *
      * @return the featuredWeight, or null if it has not been set
      */
     public String getFeaturedWeight();
@@ -133,7 +134,7 @@ public interface RepositoryResource {
      * Gets the version from the applies to field for the applies to entry that matches the supplied product definition.
      * Note that version information in the ProductDefinition is ignored, we match against the productId, InstallType
      * and ensure the edition supplied is one in the editions list in the applies to.
-     * 
+     *
      * @param def The product definition to look for in the appliesTo field.
      * @return The version, as read from the appliesTo field
      */
@@ -143,14 +144,14 @@ public interface RepositoryResource {
      * Gets the "main" attachment for this resource. It will cycle through the assets asking the
      * resource if the attachment is the "main" one, it will stop once it finds the first
      * attachment that satisfies that criteria.
-     * 
+     *
      * @return the first attachment considered to be a "main" attachment, or null if there is no "main" attachment
      */
     public AttachmentResource getMainAttachment() throws RepositoryBackendException, RepositoryResourceException;
 
     /**
      * Get an {@link AttachmentResource} for the specified attachment name
-     * 
+     *
      * @param attachmentName The name of the attachment to look for
      * @return An {@link AttachmentResource} object that matches the supplied name
      */
@@ -160,7 +161,7 @@ public interface RepositoryResource {
      * This returns a a {@link Collection} of {@link AttachmentResource} objects associated with the asset. We cache
      * the list of attachments by obtaining a new asset if the current asset doesn't have any. To force
      * the asset to be refreshed from massive call {@link #refreshFromMassive()} method.
-     * 
+     *
      * @return a {@link List} of {@link AttachmentResource} objects. This collection is unmodifiable, however
      *         methods like delete may be called on the AttachmentResources within the collection
      * @throws RepositoryException
@@ -171,7 +172,7 @@ public interface RepositoryResource {
      * Returns the combined License Agreement and License Information HTML attachment that best matches the given locale.
      * <p>
      * If no LA+LI attachment matches the given locale, the English attachment will be returned. If there is no English attachment then null will be returned.
-     * 
+     *
      * @param loc the locale to match against
      * @return the LA+LI HTML attachment that best matches the given locale, or null if one could not be found
      */
@@ -181,7 +182,7 @@ public interface RepositoryResource {
      * Returns the License Agreement attachment that best matches the given locale.
      * <p>
      * If no LA attachment matches the given locale, the English attachment will be returned. If there is no English attachment then null will be returned.
-     * 
+     *
      * @param loc the locale to match against
      * @return the LA attachment that best matches the given locale, or null if one could not be found
      */
@@ -191,7 +192,7 @@ public interface RepositoryResource {
      * Returns the License Information attachment that best matches the given locale.
      * <p>
      * If no LI attachment matches the given locale, the English attachment will be returned. If there is no English attachment then null will be returned.
-     * 
+     *
      * @param loc the locale to match against
      * @return the LI attachment that best matches the given locale, or null if one could not be found
      */
@@ -199,7 +200,7 @@ public interface RepositoryResource {
 
     /**
      * Gets the license type of the resource
-     * 
+     *
      * @return the license type of the resource, or null if it has not been set
      */
     public LicenseType getLicenseType();
@@ -207,35 +208,42 @@ public interface RepositoryResource {
     /**
      * Gets the value of the LicenseId.
      * For features, this is contained in the Subsystem-License header
-     * 
+     *
      * @return the license id, or null if it has not been set
      */
     public String getLicenseId();
 
     /**
      * Get the short description of the asset
-     * 
+     *
      * @return The short description of the asset, or null if it has not been set
      */
     public String getShortDescription();
 
     /**
      * Get the {@link DisplayPolicy}
-     * 
+     *
      * @return {@link DisplayPolicy} in use, or null if it has not been set
      */
     public DisplayPolicy getDisplayPolicy();
 
     /**
+     * Get the {@link WlpInformation} version of the asset
+     *
+     * @return The {@link WlpInformation} version of the asset
+     */
+    public String getWlpInformationVersion();
+
+    /**
      * Writes the directory based repository formatted JSON to the supplied output stream
-     * 
+     *
      * @param writeJsonTo The output stream the JSON should be written to
      */
     public void writeDiskRepoJSONToStream(final OutputStream writeJsonTo) throws RepositoryResourceException;
 
     /**
      * This method dumps a formatted JSON string to the supplied out stream
-     * 
+     *
      * @param os The output stream the JSON should be dumped too.
      */
     public void dump(OutputStream os);

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/GenericRequirement.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/GenericRequirement.java
@@ -1,0 +1,71 @@
+/*
+ * IBM Confidential
+ *
+ * OCO Source Materials
+ *
+ * WLP Copyright IBM Corp. 2016
+ *
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
+ * U.S. Copyright Office.
+ */
+
+package com.ibm.ws.repository.resources.internal;
+
+import java.util.Map;
+
+import org.apache.aries.util.manifest.ManifestHeaderProcessor.GenericMetadata;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+
+/**
+ * A {@link Requirement} implementation backed by a {@link GenericMetadata} instance.
+ */
+public class GenericRequirement implements Requirement {
+
+    private final GenericMetadata delegate;
+
+    /**
+     * @param delegate
+     */
+    public GenericRequirement(GenericMetadata delegate) {
+        this.delegate = delegate;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.osgi.resource.Requirement#getNamespace()
+     */
+    @Override
+    public String getNamespace() {
+        return this.delegate.getNamespace();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.osgi.resource.Requirement#getDirectives()
+     */
+    @Override
+    public Map<String, String> getDirectives() {
+        return this.delegate.getDirectives();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.osgi.resource.Requirement#getAttributes()
+     */
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.delegate.getAttributes();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Resource getResource() {
+        return null;
+    }
+
+}

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/RepositoryResourceImpl.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/RepositoryResourceImpl.java
@@ -853,6 +853,18 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
 
     /** {@inheritDoc} */
     @Override
+    public void setWlpInformationVersion(String wlpInformationVersion) {
+        _asset.getWlpInformation().setWlpInformationVersion(wlpInformationVersion);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getWlpInformationVersion() {
+        return _asset.getWlpInformation().getWlpInformationVersion();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void setDisplayPolicy(DisplayPolicy policy) {
         _asset.getWlpInformation().setDisplayPolicy(policy);
     }
@@ -1012,6 +1024,7 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
         setFeaturedWeight(fromResource.getFeaturedWeight());
         setDisplayPolicy(fromResource.getDisplayPolicy());
         setVanityURL(fromResource.getVanityURL());
+        setWlpInformationVersion(fromResource.getWlpInformationVersion());
 
         if (includeAttachmentInfo) {
             setMainAttachmentSize(fromResource.getMainAttachmentSize());

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/ProductRelatedResourceWritable.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/ProductRelatedResourceWritable.java
@@ -28,44 +28,58 @@ public interface ProductRelatedResourceWritable extends ProductRelatedResource, 
 
     /**
      * Sets the productId for the resource
-     * 
+     *
      * @param productId the product id
      */
     public void setProductId(String productId);
 
     /**
      * Sets the edition of the product
-     * 
+     *
      * @param edition the edition of the product
      */
     public void setProductEdition(String edition);
 
     /**
      * Sets the install type if the product (e.g. "Archive")
-     * 
+     *
      * @param productInstallType the install type
      */
     public void setProductInstallType(String productInstallType);
 
     /**
      * Sets the version of the product
-     * 
+     *
      * @param version the product version
      */
     public void setProductVersion(String version);
 
     /**
      * Sets the features included in this product
-     * 
+     *
      * @param provideFeature the symbolic names of features provided by this product
      */
     public void setProvideFeature(Collection<String> provideFeature);
 
     /**
      * Sets the features that this product depends on
-     * 
+     *
      * @param requireFeature the symbolic names of features required by this product
      */
     public void setRequireFeature(Collection<String> requireFeature);
+
+    /**
+     * Sets the collection of OSGi requirements this product has
+     *
+     * @param genericRequirements The OSGi requirements for this product
+     */
+    public void setGenericRequirements(String genericRequirements);
+
+    /**
+     * Sets the version information for the Java packaged with this product
+     *
+     * @param packagedJava The version information for the packaged Java
+     */
+    public void setPackagedJava(String packagedJava);
 
 }

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/RepositoryResourceWritable.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/RepositoryResourceWritable.java
@@ -33,6 +33,7 @@ import com.ibm.ws.repository.exceptions.RepositoryResourceDeletionException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceException;
 import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.strategies.writeable.UploadStrategy;
+import com.ibm.ws.repository.transport.model.WlpInformation;
 
 /**
  * Represents a resource which could be written to a repository.
@@ -300,6 +301,13 @@ public interface RepositoryResourceWritable extends RepositoryResource {
      * @param lic the license id
      */
     public void setLicenseId(String lic);
+
+    /**
+     * Sets the {@link WlpInformation} version of the asset
+     *
+     * @param wlpInformationVersion The {@link WlpInformation} version to use for the asset
+     */
+    public void setWlpInformationVersion(String wlpInformationVersion);
 
     /**
      * Uploads the resource to the repository using the supplied strategy

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/model/WlpInformation.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/model/WlpInformation.java
@@ -36,7 +36,7 @@ import com.ibm.ws.repository.transport.exceptions.BadVersionException;
 public class WlpInformation extends AbstractJSON implements VersionableContent, HasBreakingChanges {
 
     public final static float MIN_VERSION = 1.0f;
-    public final static float MAX_VERSION = 2.0f; // up to but not including
+    public final static float MAX_VERSION = 3.0f; // up to but not including
 
     private ResourceTypeLabel typeLabel;
     private String productVersion;
@@ -68,6 +68,8 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
     private Collection<String> supersededByOptional;
     private JavaSEVersionRequirements javaSEVersionRequirements;
     private String mainAttachmentSHA256;
+    private String genericRequirements;
+    private String packagedJava;
 
     public String getFeaturedWeight() {
         return featuredWeight;
@@ -230,7 +232,7 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
 
     /**
      * Sets the short name to the supplied value and also sets a lower case version obtainable via the {@link #getLowerCaseShortName()}.
-     * 
+     *
      * @param shortName
      */
     public void setShortName(String shortName) {
@@ -377,6 +379,22 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
 
     public void setJavaSEVersionRequirements(JavaSEVersionRequirements javaSEVersionRequirements) {
         this.javaSEVersionRequirements = javaSEVersionRequirements;
+    }
+
+    public String getGenericRequirements() {
+        return genericRequirements;
+    }
+
+    public void setGenericRequirements(String genericRequirements) {
+        this.genericRequirements = genericRequirements;
+    }
+
+    public String getPackagedJava() {
+        return packagedJava;
+    }
+
+    public void setPackagedJava(String packagedJava) {
+        this.packagedJava = packagedJava;
     }
 
     @Override
@@ -648,6 +666,22 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
                 return false;
             }
         } else if (!mainAttachmentSHA256.equals(other.mainAttachmentSHA256)) {
+            return false;
+        }
+
+        if (genericRequirements == null) {
+            if (other.genericRequirements != null) {
+                return false;
+            }
+        } else if (!genericRequirements.equals(other.genericRequirements)) {
+            return false;
+        }
+
+        if (packagedJava == null) {
+            if (other.packagedJava != null) {
+                return false;
+            }
+        } else if (!packagedJava.equals(other.packagedJava)) {
             return false;
         }
 


### PR DESCRIPTION
(e.g. zips with Java)
New fields have been added to WlpInformation, one to hold an OSGi requirement detailing the platform information, and the other to store details of the JVM packaged with the asset. The max wlpInformationVersion has also been increased so that only new clients will display platform specific assets.
