### PR TITLE
Show dist task under distribution group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ subprojects {
 
 task dist(type: Sync) {
     description 'Produce distribution archives, and copy them to the build/distributions directory'
+    group 'distribution'
     into 'build/distributions'
     from subprojects*.getTasksByName('dist', false)
 }


### PR DESCRIPTION
The dist task isn't show in the gradle task view unless show all tasks is toggled on. This change makes it visible without having to toggle on all other tasks.
