### PR TITLE
Users should not see unpublished assets in count requests.

### DIFF
--- a/server/src/main/java/com/ibm/ws/lars/rest/AssetFilter.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/AssetFilter.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.ibm.ws.lars.rest;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,31 +31,21 @@ import java.util.List;
 
 public class AssetFilter {
 
-    public AssetFilter() {}
-
     public AssetFilter(String key, List<Condition> conditions) {
         this.key = key;
-        this.conditions = conditions;
+        this.conditions = Collections.unmodifiableList(conditions);
     }
 
-    private String key;
+    private final String key;
 
     public String getKey() {
         return key;
     }
 
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    private List<Condition> conditions;
+    private final List<Condition> conditions;
 
     public List<Condition> getConditions() {
         return conditions;
-    }
-
-    public void setConditions(List<Condition> conditions) {
-        this.conditions = conditions;
     }
 
     /** {@inheritDoc} */

--- a/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
@@ -101,7 +101,7 @@ public class RepositoryRESTResourceLoggingTest {
     }
 
     @Test
-    public void testCountAssets(@Mocked final Logger logger, @Mocked final UriInfo info) throws URISyntaxException, InvalidParameterException {
+    public void testCountAssets(@Mocked final Logger logger, @Mocked final UriInfo info, @Mocked SecurityContext sc) throws URISyntaxException, InvalidParameterException {
 
         new Expectations() {
             {
@@ -117,7 +117,7 @@ public class RepositoryRESTResourceLoggingTest {
             }
         };
 
-        getRestResource().countAssets(info);
+        getRestResource().countAssets(info, sc);
     }
 
     @Test


### PR DESCRIPTION
I.e. the count returned from a head request to /assets should only
include assets visible to the user role making the request
