### PR TITLE
Use static HttpClient in server tests

### DIFF
--- a/server/config/baseUrlServer.xml
+++ b/server/config/baseUrlServer.xml
@@ -46,6 +46,8 @@ limitations under the License.
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
         <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
+    
+    <webAppSecurity singleSignonEnabled="false"/>
 
     <httpEndpoint httpPort="@HTTP_PORT@" id="defaultHttpEndpoint"/>
 

--- a/server/config/bluemixServer.xml
+++ b/server/config/bluemixServer.xml
@@ -45,6 +45,8 @@ in the configDropins/overrides directory.
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
         <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
+    
+    <webAppSecurity singleSignonEnabled="false"/>
 
     <!--  These will be overwritten by bluemix -->
     <httpEndpoint httpPort="80" httpsPort="443" id="defaultHttpEndpoint"/>

--- a/server/config/testServer.xml
+++ b/server/config/testServer.xml
@@ -46,6 +46,8 @@ limitations under the License.
     <library id="mongo-lib" apiTypeVisibility="spec,ibm-api,api,third-party">
         <file name="${shared.resource.dir}/libs/mongo-java-driver-2.13.0.jar"/>
     </library>
+    
+    <webAppSecurity singleSignonEnabled="false"/>
 
     <httpEndpoint httpPort="@HTTP_PORT@" httpsPort="@HTTPS_PORT@" id="defaultHttpEndpoint"/>
 

--- a/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
@@ -137,7 +137,6 @@ public class ApiTest {
         assertEquals("Wrong number of assets", 2, assets.size());
         RepositoryContext userRepository = RepositoryContext.toUserContext(repository);
         AssetList userAssets = userRepository.doGetAllAssets();
-        userRepository.close();
         assertEquals("Wrong number of assets", 1, userAssets.size());
         assertEquals("The wrong asset was retrieved", publishedAsset.get_id(), userAssets.get(0).get_id());
     }

--- a/server/src/fat/java/com/ibm/ws/lars/rest/BluemixTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/BluemixTest.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 
 import org.apache.http.Header;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.Test;
 
 import com.ibm.ws.lars.testutils.FatUtils;
@@ -41,17 +41,16 @@ public class BluemixTest {
      */
     @Test
     public void testRedirect() throws ClientProtocolException, IOException {
-        HttpResponse resp;
-        try (RepositoryContext repository = new RepositoryContext(FatUtils.BLUEMIX_HTTP_URL, null, null, RepositoryContext.Redirects.NO_FOLLOW)) {
-            resp = repository.doRawGet("");
-        }
-        StatusLine statusLine = resp.getStatusLine();
-        int actualStatusCode = statusLine.getStatusCode();
-        assertEquals("The http response code was incorrect", 302, actualStatusCode);
-        Header[] headers = resp.getHeaders("Location");
-        assertEquals("The number of location headers was wrong.", 1, headers.length);
-        assertEquals("The redirect in the location header is pointing to the wrong place",
-                     FatUtils.BLUEMIX_HTTPS_URL, headers[0].getValue());
-    }
+        RepositoryContext repository = new RepositoryContext(FatUtils.BLUEMIX_HTTP_URL, null, null, RepositoryContext.Redirects.NO_FOLLOW);
+        try (CloseableHttpResponse resp = repository.doRawGet("")) {
 
+            StatusLine statusLine = resp.getStatusLine();
+            int actualStatusCode = statusLine.getStatusCode();
+            assertEquals("The http response code was incorrect", 302, actualStatusCode);
+            Header[] headers = resp.getHeaders("Location");
+            assertEquals("The number of location headers was wrong.", 1, headers.length);
+            assertEquals("The redirect in the location header is pointing to the wrong place",
+                         FatUtils.BLUEMIX_HTTPS_URL, headers[0].getValue());
+        }
+    }
 }

--- a/server/src/fat/java/com/ibm/ws/lars/rest/PermissionTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/PermissionTest.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import org.apache.http.ParseException;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.entity.ContentType;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,13 +55,6 @@ public class PermissionTest {
 
     // This is not a rule, as a rule does setup/tear down which is not wanted.
     public RepositoryContext testContext;
-
-    @After
-    public void closeUserContext() {
-        if (testContext != null) {
-            testContext.close();
-        }
-    }
 
     /**
      * HTTP URL for the test instance where read operations are restricted to users with the User


### PR DESCRIPTION
This removes the need to close RepositoryContext

Config options are set on each request rather than on the client when it
is created.

Also ensure that tests close their http requests and that the Http
client does not store cookies.

Fixes #108 
