### PR TITLE
Ignore buildship config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 # Eclipse stuff
 */.settings/**
 !*/.settings/org.eclipse.*.prefs
+*/.settings/org.eclipse.buildship.*.prefs
 */.classpath
 */.project
 */bin


### PR DESCRIPTION
Add the settings files created by newer versions of buildship to .gitignore
