### PR TITLE
make getAssetReviews & getAttachments hide unpublished assets from users

### DIFF
--- a/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
@@ -462,6 +462,15 @@ public class RepositoryContext extends ExternalResource {
         return jsonReader.readValue(resultJson, new TypeReference<List<Map<String, Object>>>() {});
     }
 
+    void getAssetReviewsBad(String id, int expectedStatusCode, String expectedMessage) throws IOException {
+        String message = doGet("/assets/" + id + "/assetreviews", expectedStatusCode);
+
+        if (expectedMessage != null) {
+            String errorMessage = parseErrorObject(message.toString());
+            assertEquals("Unexpected message from server", expectedMessage, errorMessage);
+        }
+    }
+
     /**
      * Get asset with the expectation that it will fail
      */

--- a/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/RepositoryRESTResourceLoggingTest.java
@@ -213,7 +213,7 @@ public class RepositoryRESTResourceLoggingTest {
     }
 
     @Test
-    public void testGetAttachmentContent(@Mocked final Logger logger) throws InvalidIdException, NonExistentArtefactException {
+    public void testGetAttachmentContent(@Mocked final Logger logger, @Mocked final SecurityContext sc) throws InvalidIdException, NonExistentArtefactException {
 
         new Expectations() {
             {
@@ -222,10 +222,12 @@ public class RepositoryRESTResourceLoggingTest {
 
                 logger.fine("getAttachmentContent called for assetId: " + NON_EXISTENT_ID
                             + " attachmentId: " + NON_EXISTENT_ID + " name: " + "no_name");
+                sc.isUserInRole("Administrator");
+                result = true;
             }
         };
 
-        getRestResource().getAttachmentContent(NON_EXISTENT_ID, NON_EXISTENT_ID, "no_name", dummyUriInfo);
+        getRestResource().getAttachmentContent(NON_EXISTENT_ID, NON_EXISTENT_ID, "no_name", dummyUriInfo, sc);
     }
 
     @Test
@@ -286,16 +288,18 @@ public class RepositoryRESTResourceLoggingTest {
     }
 
     @Test
-    public void testGetAssetReviews(@Mocked final Logger logger) throws InvalidIdException, NonExistentArtefactException {
+    public void testGetAssetReviews(@Mocked final Logger logger, @Mocked final SecurityContext sc) throws InvalidIdException, NonExistentArtefactException {
 
         new Expectations() {
             {
                 logger.isLoggable(Level.FINE);
                 result = true;
                 logger.fine("getAssetReviews called with id of 'ffffffffffffffffffffffff'");
+                sc.isUserInRole("Administrator");
+                result = true;
             }
         };
 
-        getRestResource().getAssetReviews(NON_EXISTENT_ID, dummyUriInfo);
+        getRestResource().getAssetReviews(NON_EXISTENT_ID, dummyUriInfo, sc);
     }
 }


### PR DESCRIPTION
Only the admin role should see unpublished assets, as per the other APIs
