### PR TITLE
Add new field to extended mathcing data which matches on platform information.

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/test/ProductResourceTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/test/ProductResourceTest.java
@@ -213,9 +213,25 @@ public class ProductResourceTest {
         addon1.setName("addon1");
 
         ProductResourceImpl addon2 = new ProductResourceImpl(null);
-        addon2.setType(ResourceType.INSTALL);
-        addon2.setName("addon1");
+        addon2.setType(ResourceType.ADDON);
+        addon2.setName("addon2");
 
         assertFalse(addon1.createMatchingData().equals(addon2.createMatchingData()));
+    }
+
+    /**
+     * Test assets with different platform info don't match
+     */
+    @Test
+    public void testDifferentPlatformInfoDontMatch() {
+        ProductResourceImpl windows = new ProductResourceImpl(null);
+        windows.setType(INSTALL);
+        windows.setGenericRequirements("osgi.native; filter:=\"(&(osgi.native.processor=x86-64)(osgi.native.osname=Win32))\"");
+
+        ProductResourceImpl linux = new ProductResourceImpl(null);
+        linux.setType(INSTALL);
+        linux.setGenericRequirements("osgi.native; filter:=\"(&(osgi.native.processor=x86-64)(osgi.native.osname=Linux))\"");
+
+        assertFalse(windows.createMatchingData().equals(linux.createMatchingData()));
     }
 }

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/ExtendedMatchingData.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/ExtendedMatchingData.java
@@ -26,6 +26,7 @@ public class ExtendedMatchingData extends RepositoryResourceMatchingData {
     String provideFeature;
     String version;
     Collection<AppliesToFilterInfo> atfi;
+    String platformInfo;
 
     /**
      * @return the provideFeature
@@ -69,6 +70,20 @@ public class ExtendedMatchingData extends RepositoryResourceMatchingData {
         this.atfi = atfi;
     }
 
+    /**
+     * @return the platformInfo
+     */
+    public String getPlatformInfo() {
+        return platformInfo;
+    }
+
+    /**
+     * @param platformInfo the platformInfo to set
+     */
+    public void setPlatformInfo(String platformInfo) {
+        this.platformInfo = platformInfo;
+    }
+
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
@@ -77,6 +92,7 @@ public class ExtendedMatchingData extends RepositoryResourceMatchingData {
         result = prime * result + ((provideFeature == null) ? 0 : provideFeature.hashCode());
         result = prime * result + ((getType() == null) ? 0 : getType().hashCode());
         result = prime * result + ((version == null) ? 0 : version.hashCode());
+        result = prime * result + ((platformInfo == null) ? 0 : platformInfo.hashCode());
         return result;
     }
 
@@ -122,6 +138,12 @@ public class ExtendedMatchingData extends RepositoryResourceMatchingData {
                     return false;
             }
         }
+
+        if (platformInfo == null) {
+            if (other.platformInfo != null)
+                return false;
+        } else if (!platformInfo.equals(other.platformInfo))
+            return false;
 
         return true;
     }

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/ProductResourceImpl.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/ProductResourceImpl.java
@@ -19,6 +19,8 @@ package com.ibm.ws.repository.resources.internal;
 import java.util.Collection;
 import java.util.List;
 
+import org.osgi.resource.Requirement;
+
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.connections.RepositoryConnection;
 import com.ibm.ws.repository.exceptions.RepositoryBackendException;
@@ -69,6 +71,13 @@ public class ProductResourceImpl extends ProductRelatedResourceImpl implements P
                 // This should only be thrown if validate editions is set to true, for us its set to false
             }
         }
+
+        for (Requirement requirement : getGenericRequirements()) {
+            if (requirement.getNamespace().equals("osgi.native")) {
+                matchingData.setPlatformInfo(requirement.getDirectives().get("filter"));
+            }
+        }
+
         return matchingData;
     }
 


### PR DESCRIPTION
This solves the problem where we have different versions of
the same asset for specific platforms and the matching data does not
recognise them as different assets. The match is based on the filter
directive which comes from an osgi requirement with a namespace of
osgi.native.
This commit also contains a fix to testDifferentNamesDontMatch(), as the
test was testing on different types rather than different names, as the
test name suggests.
