### PR TITLE
Fixes to handling of unchanged assets

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/strategies/test/StrategyTestBaseClass.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/strategies/test/StrategyTestBaseClass.java
@@ -75,14 +75,10 @@ public abstract class StrategyTestBaseClass {
 
     @Test
     public void checkLifeCycleOnUpdate() throws RepositoryBackendException, RepositoryResourceException {
-        int featured = 0;
         _testRes.uploadToMassive(new UpdateInPlaceStrategy());
         for (State startingState : State.values()) {
             for (State targetState : getValidTargetStates(startingState)) {
                 _testRes.moveToState(startingState);
-                // Increment featured weight to force an update
-                featured++;
-                _testRes.setFeaturedWeight("" + featured);
                 _testRes.uploadToMassive(createStrategy(targetState, targetState));
                 SampleResourceImpl readBack = (SampleResourceImpl) repoConnection.getResource(_testRes.getId());
                 assertEquals("Make sure state was set to target state", targetState, readBack.getState());

--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/test/ResourceTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/test/ResourceTest.java
@@ -229,6 +229,10 @@ public class ResourceTest {
         assertTrue("The resource uploaded is not equivalent to the one extracted from massive",
                    sampleRes.equivalent(readBack));
 
+        sampleRes.moveToState(PUBLISHED);
+        assertTrue("The resource is not equivalent after being published",
+                   sampleRes.equivalent(readBack));
+
         sampleRes.setDescription("new description");
         assertFalse("The resource has been updated and shouldn't be equivalent to the one obtained from massive",
                     sampleRes.equivalent(readBack));

--- a/client-lib/src/main/java/com/ibm/ws/repository/strategies/writeable/AddThenDeleteStrategy.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/strategies/writeable/AddThenDeleteStrategy.java
@@ -184,6 +184,9 @@ public class AddThenDeleteStrategy extends AddNewStrategy {
                     }
                 }
             }
+
+            // Finally, make sure the existing asset is in the desired state
+            resource.moveToState(getTargetState(firstMatch));
         }
         resource.refreshFromMassive();
     }

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/model/Asset.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/model/Asset.java
@@ -360,6 +360,12 @@ public class Asset extends AbstractJSON {
         } else if (!inMyStore.equals(other.inMyStore))
             return false;
 
+        if (reviewed == null) {
+            if (other.reviewed != null)
+                return false;
+        } else if (!reviewed.equals(other.reviewed))
+            return false;
+
         if (state == null) {
             if (other.state != null)
                 return false;
@@ -444,12 +450,6 @@ public class Asset extends AbstractJSON {
             if (other.provider != null)
                 return false;
         } else if (!provider.equals(other.provider))
-            return false;
-
-        if (reviewed == null) {
-            if (other.reviewed != null)
-                return false;
-        } else if (!reviewed.equals(other.reviewed))
             return false;
 
         if (type == null) {


### PR DESCRIPTION
Two fixes to the way the client handles unchanged assets.

Usually, when we upload an asset, we look to see if we're replacing an existing asset. If we are, we check to see if the two assets are "equivalent" (the same if we ignore fields which are set automatically by the server) and if so, we skip doing the upload.
1. The `reviewed` is set by the server when an asset is moved to `Published` state. This field should be excluded from the equivalence check
2. If we decide to skip the upload, we should still move the asset into the state requested on the upload.
