### PR TITLE
Gradle fixups

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -125,8 +125,8 @@ test {
 }
 
 testFat {
-	dependsOn 'startBaseUrlServer'
-	finalizedBy 'stopBaseUrlServer'
+    dependsOn 'startBaseUrlServer'
+    finalizedBy 'stopBaseUrlServer'
 }
 
 task initAnt << {
@@ -373,7 +373,7 @@ task testLarsPackage(type: JavaExec) {
     description "Test that 'java -jar larsServerPackage.jar' will at least run and fail in an expected manner, and some limited check on the jar contents"
     String badDirName = "jibberjibberjibberfoogogogo";
     ignoreExitValue = true // Expecting this to fail
-    workingDir '.'
+    workingDir 'build'
     main = '-jar'
     standardOutput = new ByteArrayOutputStream() // Hide the stdout from the screen.
     errorOutput = new ByteArrayOutputStream()
@@ -404,7 +404,7 @@ task testJarContents {
 }
 
 task packageBluemixLars(type: Zip) {
-	
+
     description 'Create a liberty packaged server zip of LARS ready for pushing to bluemix'
 
     from(configurations.sharedLibs) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -324,9 +324,13 @@ task createLarsPackage {
     dependsOn 'createPackageUsrDir'
     
 
-    def packageJarFileDest = 'build/distributions/' + archivesBaseName + 'Package.jar'
+    def packageJarFileDest = 'build/distributions/' + archivesBaseName + 'Package.jar' 
     
     outputs.file packageJarFileDest
+
+    inputs.file 'config/server.xml'
+    inputs.files rootProject.file('LICENSE'), rootProject.file('LA_en')
+    inputs.files(war.getOutputs().getFiles())
 
     doLast {
         mkdir('build/distributions')

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -373,6 +373,9 @@ task testLarsPackage(type: JavaExec) {
     // with a non-existent destination
     
     dependsOn 'createLarsPackage'
+    outputs.upToDateWhen {
+        !createLarsPackage.didWork
+    }
     
     description "Test that 'java -jar larsServerPackage.jar' will at least run and fail in an expected manner, and some limited check on the jar contents"
     String badDirName = "jibberjibberjibberfoogogogo";


### PR DESCRIPTION
A few things to make the gradle build work better. Don't do tasks when not required, do do tasks when they are required. Fixes #131 
