### PR TITLE
Remove default port numbers from attachment URLs

### DIFF
--- a/server/src/test/java/com/ibm/ws/lars/rest/ConfigurationTest.java
+++ b/server/src/test/java/com/ibm/ws/lars/rest/ConfigurationTest.java
@@ -18,6 +18,9 @@ package com.ibm.ws.lars.rest;
 import static mockit.Deencapsulation.invoke;
 import static org.junit.Assert.assertEquals;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.junit.Test;
 
 /**
@@ -32,6 +35,22 @@ public class ConfigurationTest {
         assertEquals("http://example.org/ma/v1/", invoke(Configuration.class, methodName, "http://example.org/"));
         assertEquals("http://example.org/wibble/ma/v1/", invoke(Configuration.class, methodName, "http://example.org/wibble"));
         assertEquals("http://example.org/wibble/ma/v1/", invoke(Configuration.class, methodName, "http://example.org/wibble/"));
+    }
+
+    @Test
+    public void testStripDefaultPort() throws URISyntaxException {
+        String methodName = "stripDefaultPort";
+
+        assertEquals(new URI("http://example.com/test"), invoke(Configuration.class, methodName, new URI("http://example.com:80/test")));
+        assertEquals(new URI("http://example.com:9080/test"), invoke(Configuration.class, methodName, new URI("http://example.com:9080/test")));
+        assertEquals(new URI("https://example.com/test"), invoke(Configuration.class, methodName, new URI("https://example.com:443/test")));
+        assertEquals(new URI("https://example.com:9443/test"), invoke(Configuration.class, methodName, new URI("https://example.com:9443/test")));
+
+        assertEquals(new URI("HTTP://example.com/test"), invoke(Configuration.class, methodName, new URI("HTTP://example.com:80/test")));
+        assertEquals(new URI("HTTP://example.com:9080/test"), invoke(Configuration.class, methodName, new URI("HTTP://example.com:9080/test")));
+
+        assertEquals(new URI("http://example.com:443/test"), invoke(Configuration.class, methodName, new URI("http://example.com:443/test")));
+        assertEquals(new URI("https://example.com:80/test"), invoke(Configuration.class, methodName, new URI("https://example.com:80/test")));
     }
 
 }


### PR DESCRIPTION
When LARS returns an HTTP URI for an attachment, it should not include
the port number if it is port 80.

Similarly, it shouldn't include an explicit port 443 in an HTTPS URI.

Note that on unix systems, applications need to be running as root to open ports below 1024. That's not easy to ensure when doing a build so I haven't added an integration test.

However, I have added a unit test and have manually tested that URIs are returned correctly when using default ports.
