### PR TITLE
Add error page descriptors to bluemix package web.xml

### DIFF
--- a/server/config/bluemixWeb.xml
+++ b/server/config/bluemixWeb.xml
@@ -30,4 +30,13 @@
 		</user-data-constraint>
 	</security-constraint>
 
+	<error-page>
+		<error-code>500</error-code>
+		<location>/error</location>
+	</error-page>
+	
+	<error-page>
+		<exception-type>javax.servlet.ServletException</exception-type>
+		<location>/error</location>
+	</error-page>
 </web-app>


### PR DESCRIPTION
In #141 I added error page descriptors to the web xml, but I forgot to add the same descriptors to the web.xml in the bluemix package.
