### PR TITLE
Fixes to deletion of attachment and attachment content

### DIFF
--- a/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
@@ -388,6 +388,33 @@ public class ApiTest {
     }
 
     /**
+     * Test that deleting an asset deletes its attachments
+     */
+    @Test
+    public void testDeleteAssetWithAttachments() throws Exception {
+        Asset testAsset = AssetUtils.getTestAsset();
+        Asset returnedAsset = repository.addAssetNoAttachments(testAsset);
+
+        Attachment att1 = AssetUtils.getTestAttachmentNoContent();
+        att1 = repository.doPostAttachmentNoContent(returnedAsset.get_id(), "att1", att1);
+
+        Attachment att2 = AssetUtils.getTestAttachmentWithContent();
+        byte[] content = "Att2 test content".getBytes("UTF-8");
+        att2 = repository.doPostAttachmentWithContent(returnedAsset.get_id(),
+                                                      "att2",
+                                                      att2,
+                                                      content,
+                                                      ContentType.APPLICATION_OCTET_STREAM);
+
+        repository.deleteAsset(returnedAsset.get_id(), -1);
+
+        assertEquals("There should be no assets", 0, repository.doGetAllAssets().size());
+
+        DB db = FatUtils.getMongoDB();
+        assertEquals("There should be no remaining attachments", 0, db.getCollection("attachments").count());
+    }
+
+    /**
      * Test getting the content of an attachment with the parent asset in various states
      */
     @Test

--- a/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
@@ -65,8 +65,6 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
-import com.mongodb.WriteConcern;
 
 /**
  * Tests for the LARS REST API, which is designed to be compatible with the legacy Massive server.
@@ -1173,11 +1171,8 @@ public class ApiTest {
     public void test500Mapping() throws InvalidJsonAssetException, ParseException, IOException {
 
         // First, make a direct connection to the database, and insert a dodgy asset
-
         String ID = "_id";
-        MongoClient mongoClient = new MongoClient("localhost:" + FatUtils.DB_PORT);
-        mongoClient.setWriteConcern(WriteConcern.JOURNAL_SAFE);
-        DB db = mongoClient.getDB(FatUtils.TEST_DB_NAME);
+        DB db = FatUtils.getMongoDB();
         DBCollection assetCollection = db.getCollection("assets");
         DBObject obj = new BasicDBObject();
         obj.put("foo", "bar");
@@ -1204,7 +1199,6 @@ public class ApiTest {
         // Remove dodgy data from the database for the next test. Don't drop anything
         // as it will remove the database indexing.
         assetCollection.remove(new BasicDBObject());
-        mongoClient.close();
     }
 
     @Test

--- a/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
@@ -65,6 +65,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+import com.mongodb.gridfs.GridFS;
 
 /**
  * Tests for the LARS REST API, which is designed to be compatible with the legacy Massive server.
@@ -385,6 +386,9 @@ public class ApiTest {
 
         AttachmentList attachmentsAfterDeletion = repository.doGetAllAttachmentsForAsset(returnedAsset.get_id());
         assertTrue("Asset should have zero attachments after deletion of only attachment", attachmentsAfterDeletion.isEmpty());
+
+        GridFS fs = new GridFS(FatUtils.getMongoDB());
+        assertEquals("Files in database after delete", 0, fs.getFileList().size());
     }
 
     /**

--- a/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
@@ -383,7 +383,8 @@ public class RepositoryContext extends ExternalResource {
     private void cleanRepo() throws InvalidJsonAssetException, IOException {
         deleteAllAssets();
         AssetList assets = doGetAllAssets();
-        assertEquals("The repository is not empty", 0, assets.size());
+        assertEquals("Assets remaining in the repository", 0, assets.size());
+        assertEquals("Attachments remaining in the repository", 0, FatUtils.getMongoDB().getCollection("attachments").count());
     }
 
     void deleteAllAssets() throws IOException, InvalidJsonAssetException {

--- a/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/RepositoryContext.java
@@ -82,6 +82,7 @@ import com.ibm.ws.lars.rest.model.AssetList;
 import com.ibm.ws.lars.rest.model.Attachment;
 import com.ibm.ws.lars.rest.model.AttachmentList;
 import com.ibm.ws.lars.testutils.FatUtils;
+import com.mongodb.gridfs.GridFS;
 
 /**
  * Context used by testcases to perform HTTP operations against one LARS server. Tests should use
@@ -385,6 +386,7 @@ public class RepositoryContext extends ExternalResource {
         AssetList assets = doGetAllAssets();
         assertEquals("Assets remaining in the repository", 0, assets.size());
         assertEquals("Attachments remaining in the repository", 0, FatUtils.getMongoDB().getCollection("attachments").count());
+        assertEquals("Files remaining in repository", 0, new GridFS(FatUtils.getMongoDB()).getFileList().size());
     }
 
     void deleteAllAssets() throws IOException, InvalidJsonAssetException {

--- a/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
@@ -313,8 +313,15 @@ public class AssetServiceLayer {
     }
 
     public void deleteAttachment(String attachmentId) {
-        persistenceBean.deleteAttachmentMetadata(attachmentId);
-        persistenceBean.deleteAttachmentContent(attachmentId);
+        try {
+            Attachment attachment = persistenceBean.retrieveAttachmentMetadata(attachmentId);
+            if (attachment.getGridFSId() != null) {
+                persistenceBean.deleteAttachmentContent(attachment.getGridFSId());
+            }
+            persistenceBean.deleteAttachmentMetadata(attachmentId);
+        } catch (NonExistentArtefactException ex) {
+            // Do nothing if attachment does not exist
+        }
     }
 
     public Attachment retrieveAttachmentMetadata(String assetId, String attachmentId, UriInfo uriInfo) throws NonExistentArtefactException {

--- a/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/AssetServiceLayer.java
@@ -200,10 +200,11 @@ public class AssetServiceLayer {
      */
     public void deleteAsset(String assetId) throws NonExistentArtefactException {
 
-        // Delete all attachments belonging to the asset
-        Asset asset = persistenceBean.retrieveAsset(assetId);
+        // Retrieve the asset to ensure it exists
+        persistenceBean.retrieveAsset(assetId);
 
-        for (Attachment attachment : asset.getAttachments()) {
+        // Delete all attachments belonging to the asset
+        for (Attachment attachment : persistenceBean.findAttachmentsForAsset(assetId)) {
             deleteAttachment(attachment.get_id());
         }
 

--- a/server/src/main/java/com/ibm/ws/lars/rest/PersistenceBean.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/PersistenceBean.java
@@ -460,8 +460,8 @@ public class PersistenceBean implements Persistor {
     }
 
     @Override
-    public void deleteAttachmentContent(String attachmentId) {
-        gridFS.remove(attachmentId);
+    public void deleteAttachmentContent(String gridFsId) {
+        gridFS.remove(gridFsId);
     }
 
     @Override

--- a/server/src/main/java/com/ibm/ws/lars/rest/Persistor.java
+++ b/server/src/main/java/com/ibm/ws/lars/rest/Persistor.java
@@ -144,10 +144,10 @@ public interface Persistor {
     public Attachment retrieveAttachmentMetadata(String attachmentId) throws NonExistentArtefactException;
 
     /**
-     * Deletes the content of the specified attachment. Caller should also delete the attachment
-     * metadata.
+     * Deletes the attachment content associated with the given gridFsId. Caller should also delete
+     * the attachment metadata.
      */
-    public void deleteAttachmentContent(String attachmentId);
+    public void deleteAttachmentContent(String gridFsId);
 
     /**
      * Deletes the metadata for the specified attachment. Callers should have already deleted


### PR DESCRIPTION
This change fixes two problems

- When an asset was deleted, the associated attachments were not being deleted
- When an attachment with content was deleted, the associated content was not being deleted

If assets are regularly added and removed from the repository, this leads to a build up of orphaned attachments and attachment content in the database which can only be removed manually.