### PR TITLE
Speed up matching ESAs

### DIFF
--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -23,11 +23,15 @@ import java.util.List;
 
 import com.ibm.ws.repository.common.enums.DisplayPolicy;
 import com.ibm.ws.repository.common.enums.DownloadPolicy;
+import com.ibm.ws.repository.common.enums.FilterPredicate;
+import com.ibm.ws.repository.common.enums.FilterableAttribute;
 import com.ibm.ws.repository.common.enums.InstallPolicy;
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.common.enums.Visibility;
 import com.ibm.ws.repository.connections.RepositoryConnection;
+import com.ibm.ws.repository.exceptions.RepositoryBackendException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceCreationException;
+import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.resources.writeable.EsaResourceWritable;
 import com.ibm.ws.repository.transport.model.AppliesToFilterInfo;
 import com.ibm.ws.repository.transport.model.Asset;
@@ -356,6 +360,20 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
         matchingData.setVersion(getVersion());
         matchingData.setProvideFeature(getProvideFeature());
         return matchingData;
+    }
+
+    @Override
+    protected Collection<? extends RepositoryResource> getPotentiallyMatchingResources() throws RepositoryBackendException {
+        Collection<RepositoryResource> resources;
+
+        if (getProvideFeature() != null) {
+            resources = _repoConnection.getMatchingResources(FilterPredicate.areEqual(FilterableAttribute.TYPE, getType()),
+                                                             FilterPredicate.areEqual(FilterableAttribute.SYMBOLIC_NAME, getProvideFeature()));
+        } else {
+            resources = _repoConnection.getMatchingResources(FilterPredicate.areEqual(FilterableAttribute.TYPE, getType()));
+        }
+
+        return resources;
     }
 
     @Override

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/RepositoryResourceImpl.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/internal/RepositoryResourceImpl.java
@@ -72,6 +72,7 @@ import com.ibm.ws.repository.exceptions.RepositoryResourceLifecycleException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceUpdateException;
 import com.ibm.ws.repository.exceptions.RepositoryResourceValidationException;
 import com.ibm.ws.repository.resources.AttachmentResource;
+import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.resources.internal.AppliesToProcessor.AppliesToEntry;
 import com.ibm.ws.repository.resources.writeable.AttachmentResourceWritable;
 import com.ibm.ws.repository.resources.writeable.RepositoryResourceWritable;
@@ -927,9 +928,8 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
     protected List<RepositoryResourceImpl> performMatching() throws BadVersionException, RequestFailureException, RepositoryBadDataException, RepositoryBackendException {
         List<RepositoryResourceImpl> matching = new ArrayList<RepositoryResourceImpl>();
 
-        // connect to massive and find that sample
         @SuppressWarnings("unchecked")
-        Collection<RepositoryResourceImpl> resources = (Collection<RepositoryResourceImpl>) new RepositoryConnectionList(_repoConnection).getAllResourcesWithDupes(getType());
+        Collection<RepositoryResourceImpl> resources = (Collection<RepositoryResourceImpl>) getPotentiallyMatchingResources();
 
         RepositoryResourceImpl resource = null;
         for (RepositoryResourceImpl res : resources) {
@@ -941,6 +941,15 @@ public abstract class RepositoryResourceImpl implements RepositoryResourceWritab
         }
 
         return matching;
+    }
+
+    /**
+     * Returns a superset of resources to those returned by {@link #performMatching()}
+     *
+     * This allows us to do some type-specific pre-filtering of the resources on the server.
+     */
+    protected Collection<? extends RepositoryResource> getPotentiallyMatchingResources() throws RepositoryBackendException {
+        return _repoConnection.getAllResourcesWithDupes(getType());
     }
 
     /**

--- a/test-utils/src/main/java/com/ibm/ws/lars/testutils/matchers/ResourceByIdMatcher.java
+++ b/test-utils/src/main/java/com/ibm/ws/lars/testutils/matchers/ResourceByIdMatcher.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.lars.testutils.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.TypeSafeMatcher;
+
+import com.ibm.ws.repository.resources.RepositoryResource;
+
+/**
+ * Matches Resources against each other by comparing only the IDs.
+ * <p>
+ * If you have added some resources and then retrieved them, you can check the list of retrieved
+ * resources is correct with
+ *
+ * <pre>
+ * assertThat(returnedResources, containsInAnyOrder(byId(res1), byId(res2), ...))
+ * </pre>
+ */
+public class ResourceByIdMatcher extends TypeSafeMatcher<RepositoryResource> {
+
+    private final String expectedId;
+
+    private ResourceByIdMatcher(String expectedId) {
+        this.expectedId = expectedId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("resource id should be ").appendValue(expectedId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean matchesSafely(RepositoryResource resource) {
+        return resource.getId().equals(expectedId);
+    }
+
+    @Factory
+    public static ResourceByIdMatcher hasId(String id) {
+        return new ResourceByIdMatcher(id);
+    }
+
+    @Factory
+    public static ResourceByIdMatcher hasId(RepositoryResource res) {
+        return new ResourceByIdMatcher(res.getId());
+    }
+
+}


### PR DESCRIPTION
Currently we do matching by getting all assets of the same type,
creating matching data for each and comparing the matching data.

Instead, when fetching from a queriable repository, we can do some
pre-filtering on indexed fields to reduce the size of the results
fetched from the server.