### PR TITLE
Improve checking of repository availability

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RestClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RestClientTest.java
@@ -114,11 +114,21 @@ public class RestClientTest {
      * @return
      */
     private String createDateString() {
-        SimpleDateFormat dateFormater = new SimpleDateFormat(
-                        "yyyy/MM/dd HH:mm:ss.SSS");
+        SimpleDateFormat dateFormater = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
         String createdString = " created at "
                                + dateFormater.format(Calendar.getInstance().getTime());
         return createdString;
+    }
+
+    /**
+     * This should not throw an exception, the repo should be available
+     *
+     * @throws IOException
+     * @throws RequestFailureException
+     */
+    @Test
+    public void testCheckRepositoryStatus() throws IOException, RequestFailureException {
+        _unauthenticatedClient.checkRepositoryStatus();
     }
 
     /**
@@ -151,13 +161,7 @@ public class RestClientTest {
 
         String attachmentUrl = fixture.getHostedFileRoot() + "/testfile.txt";
 
-        AttachmentSummary attachmentSummary = new MockAttachmentSummary(
-                        new File(resourcesDir, "TestAttachment.txt"),
-                        "TestAttachment.txt",
-                        AttachmentType.CONTENT,
-                        0,
-                        attachmentUrl
-                        );
+        AttachmentSummary attachmentSummary = new MockAttachmentSummary(new File(resourcesDir, "TestAttachment.txt"), "TestAttachment.txt", AttachmentType.CONTENT, 0, attachmentUrl);
 
         createdAttachment = _writeableClient.addAttachment(createdAsset.get_id(), attachmentSummary);
         assertEquals("The attachment asset ID should match the asset ID",
@@ -167,8 +171,7 @@ public class RestClientTest {
                      createdAttachment.getUrl());
 
         InputStream attachmentContentStream = _client.getAttachment(createdAsset, createdAttachment);
-        BufferedReader attachmentContentReader = new BufferedReader(
-                        new InputStreamReader(attachmentContentStream));
+        BufferedReader attachmentContentReader = new BufferedReader(new InputStreamReader(attachmentContentStream));
         assertEquals("The content in the attachment should be the testfile content",
                      "This is a test file",
                      attachmentContentReader.readLine());

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/exceptions/RequestFailureException.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/exceptions/RequestFailureException.java
@@ -41,7 +41,7 @@ public class RequestFailureException extends Exception {
 
     /**
      * Returns the response code from the HTTP URL connection when connecting to the repository backend.
-     * 
+     *
      * @return The response code
      * @see HttpURLConnection#getResponseCode()
      */
@@ -51,7 +51,7 @@ public class RequestFailureException extends Exception {
 
     /**
      * Returns the error message written to the error stream on the HTTP URL connection when connecting to the repository backend.
-     * 
+     *
      * @return The error message
      * @see HttpURLConnection#getErrorStream()
      */
@@ -61,7 +61,7 @@ public class RequestFailureException extends Exception {
 
     /**
      * Returns the full contents of the error stream.
-     * 
+     *
      * @return The contents of the error stream
      * @see HttpURLConnection#getErrorStream()
      */


### PR DESCRIPTION
- Check that the headers in the response contain a "count" field on top
of the existing check that ensures we get an OK response code. This
should filter out any "helpful" router pages that return a response code
of OK while showing an error page.