### PR TITLE
Add test for the behaviour of an empty filter

### DIFF
--- a/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
+++ b/server/src/fat/java/com/ibm/ws/lars/rest/ApiTest.java
@@ -867,6 +867,17 @@ public class ApiTest {
         assertEquals("Unexpected number of assets retrieved", 1, assets6.size());
         assertEquals("The wrong asset was retrieved.", testAsset3.get_id(), assets6.get(0).get_id());
 
+        // Test what assets are returned if we set a filter to an empty value
+        // Assets should only be returned if they have the relevant property
+        // set to an empty value.
+        // This is a change from the massive behaviour which would have returned
+        // all assets
+        AssetList blankFilterList = repository.getAllAssets("foo=");
+        assertEquals("Unexpected number of assets retrieved", 0, blankFilterList.size());
+        addLittleAsset("foo", "");
+        AssetList assets7 = repository.getAllAssets("foo=");
+        assertEquals("Unexpected number of assets retrieved", 1, assets7.size());
+
     }
 
     @Test


### PR DESCRIPTION
If a filter is specified with an empty value, it is treated as
though filtering for assets which an empty value for the property.
Add a test for this behaviour, as it wasn't previously tested.
N.B. This behavious is different to the behaviour of the legacy
Massive repository server, but no clients rely on the old behaviour
so it should be safe to change it.