### PR TITLE
Added a Loose File Repository

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RepositoryClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RepositoryClientTest.java
@@ -51,6 +51,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.ibm.ws.lars.testutils.FatUtils;
 import com.ibm.ws.lars.testutils.fixtures.FileRepositoryFixture;
+import com.ibm.ws.lars.testutils.fixtures.LooseFileRepositoryFixture;
 import com.ibm.ws.lars.testutils.fixtures.RepositoryFixture;
 import com.ibm.ws.lars.testutils.fixtures.ZipRepositoryFixture;
 import com.ibm.ws.repository.common.enums.AttachmentType;
@@ -90,6 +91,7 @@ public class RepositoryClientTest {
         }
         parameters.add(new Object[] { ZipRepositoryFixture.createFixture(new File("testZipRepo.zip")) });
         parameters.add(new Object[] { FileRepositoryFixture.createFixture(new File("testFileRepo")) });
+        parameters.add(new Object[] { LooseFileRepositoryFixture.createFixture(new File("")) });
         Object[][] params = parameters.toArray(new Object[parameters.size()][]);
         return params;
     }
@@ -178,6 +180,7 @@ public class RepositoryClientTest {
 
     @Test
     public void testAttachmentEquivalent() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -240,6 +243,7 @@ public class RepositoryClientTest {
 
     @Test
     public void testAddAttachmentWithInfo() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -265,6 +269,7 @@ public class RepositoryClientTest {
      */
     @Test
     public void testAssetEquivalent() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset1 = _writeableClient.addAsset(newAsset);
@@ -324,6 +329,7 @@ public class RepositoryClientTest {
      */
     @Test
     public void testAttachmentNotEquivalent() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -351,6 +357,7 @@ public class RepositoryClientTest {
      */
     @Test
     public void testAttachmentNoTypeSpecified() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -373,6 +380,7 @@ public class RepositoryClientTest {
      */
     @Test
     public void testAddAttachment() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         String name = "TestAttachment.txt";
         Asset newAsset = createTestAsset();
@@ -393,8 +401,7 @@ public class RepositoryClientTest {
 
         // Get the attachment content to make sure it was added ok
         InputStream attachmentContentStream = _client.getAttachment(createdAsset, createdAttachment);
-        BufferedReader attachmentContentReader = new BufferedReader(
-                        new InputStreamReader(attachmentContentStream));
+        BufferedReader attachmentContentReader = new BufferedReader(new InputStreamReader(attachmentContentStream));
         assertEquals("The content in the attachment should be the same as what was uploaded",
                      "This is a test attachment",
                      attachmentContentReader.readLine());
@@ -403,6 +410,7 @@ public class RepositoryClientTest {
 
     @Test
     public void testGetAllAssetsDoesntGetAttachments() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -418,6 +426,7 @@ public class RepositoryClientTest {
 
     @Test
     public void testGetAssetGetsAttachments() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -440,8 +449,7 @@ public class RepositoryClientTest {
 
         // Get the attachment content to make sure it was added ok
         InputStream attachmentContentStream = _client.getAttachment(createdAsset, readAttachment);
-        BufferedReader attachmentContentReader = new BufferedReader(
-                        new InputStreamReader(attachmentContentStream));
+        BufferedReader attachmentContentReader = new BufferedReader(new InputStreamReader(attachmentContentStream));
         assertEquals(
                      "The content in the attachment should be the same as what was uploaded",
                      "This is a test attachment",
@@ -463,6 +471,7 @@ public class RepositoryClientTest {
      */
     @Test
     public void testDeleteAssetAndAttachments() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachments to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -526,6 +535,7 @@ public class RepositoryClientTest {
      */
     @Test
     public void testUpdateAttachment() throws Exception {
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         // Add an asset that we'll add the attachment to
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
@@ -539,8 +549,7 @@ public class RepositoryClientTest {
 
         try {
             attachmentContentStream = _client.getAttachment(createdAsset, createdAttachment);
-            attachmentContentReader = new BufferedReader(
-                            new InputStreamReader(attachmentContentStream));
+            attachmentContentReader = new BufferedReader(new InputStreamReader(attachmentContentStream));
             assertEquals(
                          "The content in the attachment should be the same as what was uploaded",
                          "This is a test attachment",
@@ -555,19 +564,14 @@ public class RepositoryClientTest {
         }
 
         // Now update
-        AttachmentSummary attachSummary = new MockAttachmentSummary(new File(getResourcesDir(), "TestAttachmentUpdated.txt"),
-                        "TestAttachment.txt",
-                        AttachmentType.CONTENT,
-                        0,
-                        null);
+        AttachmentSummary attachSummary = new MockAttachmentSummary(new File(getResourcesDir(), "TestAttachmentUpdated.txt"), "TestAttachment.txt", AttachmentType.CONTENT, 0, null);
         attachSummary.getAttachment().set_id(createdAttachment.get_id());
 
         Attachment updatedAttachment = _writeableClient.updateAttachment(createdAsset.get_id(), attachSummary);
 
         try {
             attachmentContentStream = _client.getAttachment(createdAsset, updatedAttachment);
-            attachmentContentReader = new BufferedReader(
-                            new InputStreamReader(attachmentContentStream));
+            attachmentContentReader = new BufferedReader(new InputStreamReader(attachmentContentStream));
             assertEquals(
                          "The content in the attachment should be the same as the udpated file",
                          "This is an updated test attachment",
@@ -677,6 +681,7 @@ public class RepositoryClientTest {
     @Test
     public void testUnauthReadAttachment() throws Exception {
 
+        assumeThat(fixture.isAttachmentSupported(), is(true));
         Asset newAsset = createTestAsset();
         Asset createdAsset = _writeableClient.addAsset(newAsset);
         final Attachment createdAttachment = new Attachment();
@@ -1494,22 +1499,20 @@ public class RepositoryClientTest {
     }
 
     protected static Attachment addAttachment(String id, final String name,
-                                              final File f, int crc) throws IOException, BadVersionException,
-                    RequestFailureException {
+                                              final File f, int crc) throws IOException, BadVersionException, RequestFailureException {
 
         // default to adding CONTENT attachment and not supplying a URL
         return addAttachment(id, name, f, crc, AttachmentType.CONTENT, null);
     }
 
-    protected static Attachment addAttachment(String id, final String name, final File f, int crc, String url)
-                    throws IOException, BadVersionException, RequestFailureException {
+    protected static Attachment addAttachment(String id, final String name, final File f, int crc, String url) throws IOException, BadVersionException, RequestFailureException {
 
         // default to adding CONTENT attachment
         return addAttachment(id, name, f, crc, AttachmentType.CONTENT, url);
     }
 
-    protected static Attachment addAttachment(String id, String name, File f, int crc, AttachmentType type, String url)
-                    throws IOException, BadVersionException, RequestFailureException {
+    protected static Attachment addAttachment(String id, String name, File f, int crc, AttachmentType type,
+                                              String url) throws IOException, BadVersionException, RequestFailureException {
         System.out.println("Adding attachment:");
         System.out.println("Asset id: " + id);
         System.out.println("File: " + f.getAbsolutePath());
@@ -1542,8 +1545,7 @@ public class RepositoryClientTest {
      * @return
      */
     private String createDateString() {
-        SimpleDateFormat dateFormater = new SimpleDateFormat(
-                        "yyyy/MM/dd HH:mm:ss.SSS");
+        SimpleDateFormat dateFormater = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
         String createdString = " created at "
                                + dateFormater.format(Calendar.getInstance().getTime());
         return createdString;

--- a/client-lib/src/main/java/com/ibm/ws/repository/connections/LooseFileRepositoryConnection.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/connections/LooseFileRepositoryConnection.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.repository.connections;
+
+import java.io.File;
+import java.util.Collection;
+
+import com.ibm.ws.repository.connections.internal.AbstractRepositoryConnection;
+import com.ibm.ws.repository.transport.client.LooseFileClient;
+import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
+
+/**
+ * Connection to a repository which consists of a loose collection of json files. No
+ * attachments are supported for this type of repository and an UnsupportedOperationException
+ * will be thrown if any attachment operations are invoked.
+ */
+public class LooseFileRepositoryConnection extends AbstractRepositoryConnection implements RepositoryConnection {
+
+    // The collection of json files that this repository represents
+    private final Collection<File> _assets;
+
+    /**
+     * @param assets The collection of json file names that this repository represents
+     */
+    public LooseFileRepositoryConnection(Collection<File> assets) {
+        _assets = assets;
+    }
+
+    /**
+     * This repository has no concept of a location since it contains a collection
+     * of loose files
+     */
+    @Override
+    public String getRepositoryLocation() {
+        return null;
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public RepositoryReadableClient createClient() {
+        return new LooseFileClient(_assets);
+    }
+
+}

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/AbstractFileClient.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/AbstractFileClient.java
@@ -27,14 +27,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import com.ibm.ws.repository.common.enums.AttachmentLinkType;
 import com.ibm.ws.repository.common.enums.AttachmentType;
-import com.ibm.ws.repository.common.enums.FilterableAttribute;
-import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.common.utils.internal.RepositoryCommonUtils;
 import com.ibm.ws.repository.transport.exceptions.BadVersionException;
 import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
@@ -87,57 +84,6 @@ public abstract class AbstractFileClient extends AbstractRepositoryClient implem
     @Override
     public Asset getAsset(final String assetId) throws IOException, BadVersionException, RequestFailureException {
         return getAsset(assetId, true);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Collection<Asset> getFilteredAssets(final Map<FilterableAttribute, Collection<String>> filters) throws IOException, RequestFailureException {
-        // Were any filters defined?
-        if (filters == null || allFiltersAreEmpty(filters)) {
-            return getAllAssets();
-        }
-
-        Collection<Asset> allAssets = getAllAssets();
-        Collection<Asset> filtered = new ArrayList<Asset>();
-
-        assetLoop: for (Asset asset : allAssets) {
-            filterAttribLoop: for (Entry<FilterableAttribute, Collection<String>> entry : filters.entrySet()) {
-                FilterableAttribute attrib = entry.getKey();
-                // List of values we are looking for
-                Collection<String> values = entry.getValue();
-                // List of values in the asset
-                Collection<String> assetValues = getValues(attrib, asset);
-
-                if (values != null && values.size() != 0) {
-                    // Check each required value and see if the asset has it
-                    for (String filterValue : values) {
-                        // if we find a match stop checking this attribute and move to next attribute
-                        if (assetValues.contains(filterValue)) {
-                            continue filterAttribLoop;
-                        }
-                    }
-                    // We never found a match for this attribute so move to next asset
-                    continue assetLoop;
-                }
-            }
-            filtered.add(asset);
-        }
-
-        return filtered;
-    }
-
-    @Override
-    public List<Asset> findAssets(final String searchString, final Collection<ResourceType> types) throws IOException, RequestFailureException {
-        Collection<Asset> assets = getAssets(types, null, null, null);
-        List<Asset> foundAssets = new ArrayList<Asset>();
-        for (Asset ass : assets) {
-            if ((ass.getName() != null && ass.getName().contains(searchString))
-                || (ass.getDescription() != null && ass.getDescription().contains(searchString))
-                || (ass.getShortDescription() != null && ass.getShortDescription().contains(searchString))) {
-                foundAssets.add(ass);
-            }
-        }
-        return foundAssets;
     }
 
     /*

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/AbstractRepositoryClient.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/AbstractRepositoryClient.java
@@ -21,7 +21,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import com.ibm.ws.repository.common.enums.FilterableAttribute;
 import com.ibm.ws.repository.common.enums.ResourceType;
@@ -50,7 +52,8 @@ public abstract class AbstractRepositoryClient implements RepositoryReadableClie
      * @throws RequestFailureException
      */
     @Override
-    public Collection<Asset> getAssets(final Collection<ResourceType> types, final Collection<String> productIds, final Visibility visibility,final Collection<String> productVersions) throws IOException, RequestFailureException {
+    public Collection<Asset> getAssets(final Collection<ResourceType> types, final Collection<String> productIds, final Visibility visibility,
+                                       final Collection<String> productVersions) throws IOException, RequestFailureException {
         return getFilteredAssets(types, productIds, visibility, productVersions, false);
     }
 
@@ -67,7 +70,8 @@ public abstract class AbstractRepositoryClient implements RepositoryReadableClie
      * @throws RequestFailureException
      */
     @Override
-    public Collection<Asset> getAssetsWithUnboundedMaxVersion(final Collection<ResourceType> types, final Collection<String> rightProductIds, final Visibility visibility) throws IOException, RequestFailureException {
+    public Collection<Asset> getAssetsWithUnboundedMaxVersion(final Collection<ResourceType> types, final Collection<String> rightProductIds,
+                                                              final Visibility visibility) throws IOException, RequestFailureException {
         return getFilteredAssets(types, rightProductIds, visibility, null, true);
     }
 
@@ -91,6 +95,57 @@ public abstract class AbstractRepositoryClient implements RepositoryReadableClie
             types = Collections.singleton(type);
         }
         return getFilteredAssets(types, null, null, null, false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<Asset> getFilteredAssets(final Map<FilterableAttribute, Collection<String>> filters) throws IOException, RequestFailureException {
+        // Were any filters defined?
+        if (filters == null || allFiltersAreEmpty(filters)) {
+            return getAllAssets();
+        }
+
+        Collection<Asset> allAssets = getAllAssets();
+        Collection<Asset> filtered = new ArrayList<Asset>();
+
+        assetLoop: for (Asset asset : allAssets) {
+            filterAttribLoop: for (Entry<FilterableAttribute, Collection<String>> entry : filters.entrySet()) {
+                FilterableAttribute attrib = entry.getKey();
+                // List of values we are looking for
+                Collection<String> values = entry.getValue();
+                // List of values in the asset
+                Collection<String> assetValues = getValues(attrib, asset);
+
+                if (values != null && values.size() != 0) {
+                    // Check each required value and see if the asset has it
+                    for (String filterValue : values) {
+                        // if we find a match stop checking this attribute and move to next attribute
+                        if (assetValues.contains(filterValue)) {
+                            continue filterAttribLoop;
+                        }
+                    }
+                    // We never found a match for this attribute so move to next asset
+                    continue assetLoop;
+                }
+            }
+            filtered.add(asset);
+        }
+
+        return filtered;
+    }
+
+    @Override
+    public List<Asset> findAssets(final String searchString, final Collection<ResourceType> types) throws IOException, RequestFailureException {
+        Collection<Asset> assets = getAssets(types, null, null, null);
+        List<Asset> foundAssets = new ArrayList<Asset>();
+        for (Asset ass : assets) {
+            if ((ass.getName() != null && ass.getName().contains(searchString))
+                || (ass.getDescription() != null && ass.getDescription().contains(searchString))
+                || (ass.getShortDescription() != null && ass.getShortDescription().contains(searchString))) {
+                foundAssets.add(ass);
+            }
+        }
+        return foundAssets;
     }
 
     /**

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/client/LooseFileClient.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/client/LooseFileClient.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.repository.transport.client;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import com.ibm.ws.repository.transport.exceptions.BadVersionException;
+import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
+import com.ibm.ws.repository.transport.model.AppliesToFilterInfo;
+import com.ibm.ws.repository.transport.model.Asset;
+import com.ibm.ws.repository.transport.model.Attachment;
+import com.ibm.ws.repository.transport.model.WlpInformation;
+
+/**
+ * This client is a file based repository which just stores json files to represent the assets.
+ * No attachments are stored in this repository and attempting to invoke methods that deal
+ * with attachments will result in an UnsupportedOperationException
+ */
+public class LooseFileClient extends AbstractRepositoryClient {
+
+    private final Collection<File> assets;
+
+    /**
+     * @param assets The collection of files this repository represents. Note that
+     *            the collection represents the asset names (i.e. the file names without the
+     *            .json extension at the end. The .json extension is automatically appended
+     *            when assets are read from the repository).
+     */
+    public LooseFileClient(Collection<File> assets) {
+        this.assets = assets;
+    }
+
+    /*
+     * ------------------------------------------------------------------------------------------------------------------
+     * PUBLIC METHODS OVERRIDEN FROM INTERFACE
+     * ------------------------------------------------------------------------------------------------------------------
+     */
+    /**
+     * Checks the repository availability
+     *
+     * @return This will return void if all is ok but will throw an exception if
+     *         there are any problems
+     * @throws FileNotFoundException
+     */
+    @Override
+    public void checkRepositoryStatus() throws IOException {
+        for (File f : assets) {
+            if (!f.exists()) {
+                throw new FileNotFoundException("Could not find " + f + " in the LooseFileRepository");
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<Asset> getAllAssets() throws IOException, RequestFailureException {
+        Collection<Asset> allAssets = new ArrayList<Asset>();
+        for (File f : assets) {
+            try {
+                allAssets.add(getAsset(f));
+            } catch (BadVersionException e) {
+                // Ignore assets with unknown versions
+            }
+        }
+        return allAssets;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Asset getAsset(final String assetId) throws IOException, BadVersionException, RequestFailureException {
+        return getAsset(new File(assetId));
+    }
+
+    @Override
+    public InputStream getAttachment(final Asset asset, final Attachment attachment) throws IOException, BadVersionException, RequestFailureException {
+        throw new UnsupportedOperationException("Loose config repositories do not support attachments");
+    }
+
+    protected Asset getAsset(final File asset) throws IOException, BadVersionException, RequestFailureException {
+        Asset ass = readJson(asset);
+        ass.set_id(asset.getAbsolutePath());
+
+        // We always get a wlp info when read back from Massive so create one if there isnt already one
+        WlpInformation wlpInfo = ass.getWlpInformation();
+        if (wlpInfo == null) {
+            wlpInfo = new WlpInformation();
+            ass.setWlpInformation(wlpInfo);
+        }
+        if (wlpInfo.getAppliesToFilterInfo() == null) {
+            wlpInfo.setAppliesToFilterInfo(Collections.<AppliesToFilterInfo> emptyList());
+        }
+        return ass;
+    }
+
+    /**
+     * @throws BadVersionException
+     * @throws IOException
+     */
+    protected Asset readJson(final File asset) throws IOException, BadVersionException {
+        FileInputStream fis = null;
+        try {
+            fis = DirectoryUtils.createFileInputStream(asset);
+            Asset ass = JSONAssetConverter.readValue(fis);
+            return ass;
+        } finally {
+            if (fis != null) {
+                fis.close();
+            }
+        }
+    }
+
+}

--- a/test-utils/src/main/java/com/ibm/ws/lars/testutils/clients/LooseFileWriteableClient.java
+++ b/test-utils/src/main/java/com/ibm/ws/lars/testutils/clients/LooseFileWriteableClient.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+* Copyright (c) 2017 IBM Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+package com.ibm.ws.lars.testutils.clients;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+
+import com.ibm.ws.repository.transport.client.DirectoryUtils;
+import com.ibm.ws.repository.transport.client.LooseFileClient;
+import com.ibm.ws.repository.transport.exceptions.BadVersionException;
+import com.ibm.ws.repository.transport.exceptions.ClientFailureException;
+import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
+import com.ibm.ws.repository.transport.model.Asset;
+import com.ibm.ws.repository.transport.model.Attachment;
+import com.ibm.ws.repository.transport.model.AttachmentSummary;
+
+/**
+ * This class uses the same backing collection as the readable client. This way it can add assets to
+ * the backing collection.
+ */
+public class LooseFileWriteableClient extends AbstractFileWriteableClient {
+
+    Collection<File> _assets;
+    File _root;
+
+    public LooseFileWriteableClient(Collection<File> assets, File root) {
+        _assets = assets;
+        _root = root;
+        _readClient = new LooseFileClient(assets);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Attachment addAttachment(String assetId, AttachmentSummary attSummary) throws IOException, BadVersionException, RequestFailureException, SecurityException {
+        throw new UnsupportedOperationException("Attachment methods should not be invoked for Loose Repositories");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deleteAttachment(String assetId, String attachmentId) throws IOException, RequestFailureException {
+        throw new UnsupportedOperationException("Attachment methods should not be invoked for Loose Repositories");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deleteAssetAndAttachments(String assetId) throws IOException, RequestFailureException {
+        DirectoryUtils.delete(new File(assetId));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void writeJson(Asset asset, String path) throws IOException, IllegalArgumentException, IllegalAccessException {
+        File targetFile = new File(path);
+        try {
+            writeDiskRepoJSONToFile(asset, targetFile);
+            System.out.println("Adding asset " + path);
+            _assets.add(targetFile);
+        } catch (NullPointerException npe) {
+            throw npe;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException
+     */
+    @Override
+    public Asset addAsset(Asset asset) throws IOException, BadVersionException, RequestFailureException, SecurityException, ClientFailureException {
+
+        File location = _root;
+        int dirDepth = (int) Math.round(Math.random() * 3);
+        for (int currentDir = 0; currentDir < dirDepth; currentDir++) {
+            location = new File(location.getAbsolutePath(), "dir" + Math.random());
+            location.mkdirs();
+        }
+        location = new File(location, "Asset" + Math.random() + ".json");
+        asset.set_id(location.getAbsolutePath());
+
+        try {
+            writeJson(asset, asset.get_id());
+        } catch (IllegalArgumentException e) {
+            throw new ClientFailureException("Failed to write the asset to disk", asset.get_id(), e);
+        } catch (IllegalAccessException e) {
+            throw new ClientFailureException("Failed to write the asset to disk", asset.get_id(), e);
+        }
+
+        // For some reason the file.io operations aren't always finished....why dont they block?
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // ignore it
+        }
+        return _readClient.getAsset(asset.get_id());
+    }
+
+    private static void writeDiskRepoJSONToFile(Asset asset, final File writeJsonTo) throws IllegalArgumentException, IllegalAccessException, IOException {
+        FileOutputStream fos = null;
+
+        // Some loose files may point at root or just specify a file and not a path. In those cases
+        // we won't have a parent directory.
+        if (writeJsonTo.getParentFile() != null) {
+            DirectoryUtils.mkDirs(writeJsonTo.getParentFile());
+        }
+        try {
+            fos = DirectoryUtils.createFileOutputStream(writeJsonTo);
+            asset.dumpMinimalAsset(fos);
+        } finally {
+            if (fos != null) {
+                fos.close();
+            }
+        }
+
+    }
+
+}

--- a/test-utils/src/main/java/com/ibm/ws/lars/testutils/fixtures/LooseFileRepositoryFixture.java
+++ b/test-utils/src/main/java/com/ibm/ws/lars/testutils/fixtures/LooseFileRepositoryFixture.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.ws.lars.testutils.fixtures;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.ibm.ws.lars.testutils.clients.LooseFileWriteableClient;
+import com.ibm.ws.repository.connections.LooseFileRepositoryConnection;
+import com.ibm.ws.repository.connections.RepositoryConnection;
+import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
+import com.ibm.ws.repository.transport.client.RepositoryWriteableClient;
+
+/**
+ * This fixture class creates the collection which will back both the readable and writable clients.
+ * Bit yucky sharing the collection like that but we need some way to update the backing collection
+ * on the readable client for the tests to work.
+ */
+public class LooseFileRepositoryFixture extends RepositoryFixture {
+
+    private final Collection<File> _assets;
+    private final File _root;
+
+    public static LooseFileRepositoryFixture createFixture(File root) {
+        Collection<File> assets = new ArrayList<File>();
+        LooseFileRepositoryConnection connection = new LooseFileRepositoryConnection(assets);
+        RepositoryConnection adminConnection = connection;
+        RepositoryConnection userConnection = connection;
+        RepositoryReadableClient adminClient = connection.createClient();
+        RepositoryReadableClient userClient = adminClient;
+        RepositoryWriteableClient writableClient = new LooseFileWriteableClient(assets, root);
+
+        return new LooseFileRepositoryFixture(adminConnection, userConnection, adminClient, writableClient, userClient, assets, root);
+    }
+
+    private LooseFileRepositoryFixture(RepositoryConnection adminConnection, RepositoryConnection userConnection, RepositoryReadableClient adminClient,
+                                       RepositoryWriteableClient writableClient, RepositoryReadableClient userClient, Collection<File> assets, File root) {
+        super(adminConnection, userConnection, adminClient, writableClient, userClient);
+        _root = root;
+        _assets = assets;
+    }
+
+    @Override
+    protected void createCleanRepository() throws Exception {
+        cleanupRepository();
+    }
+
+    @Override
+    protected void cleanupRepository() throws Exception {
+
+        // Delete all the json files
+        for (File f : _assets) {
+            if (f.exists()) {
+                f.delete();
+            }
+        }
+
+        // Clear out the file from list from the repository
+        _assets.clear();
+    }
+
+    @Override
+    public String toString() {
+        return "Loose file repo";
+    }
+
+    /**
+     * This repository does not support attachments
+     */
+    @Override
+    public boolean isAttachmentSupported() {
+        return false;
+    }
+
+    public LooseFileRepositoryConnection getWritableConnection() {
+        return new LooseFileRepositoryConnection(_assets) {
+            @Override
+            public RepositoryReadableClient createClient() {
+                return new LooseFileWriteableClient(_assets, _root);
+            }
+        };
+    }
+
+}

--- a/test-utils/src/main/java/com/ibm/ws/lars/testutils/fixtures/RepositoryFixture.java
+++ b/test-utils/src/main/java/com/ibm/ws/lars/testutils/fixtures/RepositoryFixture.java
@@ -125,6 +125,15 @@ public abstract class RepositoryFixture implements TestRule {
     }
 
     /**
+     * Returns true if this repository supports attachments
+     * 
+     * @return
+     */
+    public boolean isAttachmentSupported() {
+        return true;
+    }
+
+    /**
      * Returns the root URL where hosted testfiles can be found
      * <p>
      * Not applicable to all repository types


### PR DESCRIPTION
Add the Loose File Repository.

- This repository only stores json files (i.e. no attachments). Invoking an attachment method will result in an UnsupportedOperationExceptin.
- The files are loose, they can be stored anywhere on the file system with the asset id being the filename (without the .json extension)
- There is no concept of a root since the files can be located anywhere.

Added a fixture to the RepositoryClientTest to ensure the existing tests work for this repository as well.