### PR TITLE
Fix failing tests for loose file repo

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RepositoryClientTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/transport/client/test/RepositoryClientTest.java
@@ -91,7 +91,7 @@ public class RepositoryClientTest {
         }
         parameters.add(new Object[] { ZipRepositoryFixture.createFixture(new File("testZipRepo.zip")) });
         parameters.add(new Object[] { FileRepositoryFixture.createFixture(new File("testFileRepo")) });
-        parameters.add(new Object[] { LooseFileRepositoryFixture.createFixture(new File("")) });
+        parameters.add(new Object[] { LooseFileRepositoryFixture.createFixture(new File("testLooseRepo")) });
         Object[][] params = parameters.toArray(new Object[parameters.size()][]);
         return params;
     }


### PR DESCRIPTION
Update tests to point to a different directory to work on linux