### PR TITLE
 Add tolerates information to the requireFeature data 

### DIFF
--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/resources/internal/test/EsaResourceImplTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/resources/internal/test/EsaResourceImplTest.java
@@ -1,0 +1,192 @@
+/*******************************************************************************
+* Copyright (c) 2017 IBM Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+package com.ibm.ws.repository.resources.internal.test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import com.ibm.ws.repository.resources.internal.EsaResourceImpl;
+import com.ibm.ws.repository.transport.model.Asset;
+import com.ibm.ws.repository.transport.model.WlpInformation;
+
+public class EsaResourceImplTest {
+
+    @Test
+    public void testAddAndSetRequireFeature() {
+        EsaResourceImpl toTest = new EsaResourceImpl(null);
+
+        // Test adding an 'old' style requireFeature
+        toTest.addRequireFeature("foo");
+        Collection<String> features = toTest.getRequireFeature();
+        assertThat(features, hasSize(1));
+        assertThat(features, hasItem("foo"));
+
+        Map<String, Collection<String>> fwt = toTest.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 1, fwt.size());
+        Collection<String> tolerates = fwt.get("foo");
+        assertNotNull("The feature foo didn't appear in the collection", tolerates);
+        assertThat(tolerates, hasSize(0));
+
+        // Test adding a new style require feature with tolerates
+        Collection<String> tolerated = Collections.singleton("tolerated");
+        toTest.addRequireFeatureWithTolerates("bar", tolerated);
+
+        Collection<String> features2 = toTest.getRequireFeature();
+        assertThat(features2, hasSize(2));
+        assertThat(features2, hasItem("bar"));
+
+        Map<String, Collection<String>> fwt2 = toTest.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 2, fwt2.size());
+        Collection<String> tolerates2 = fwt2.get("bar");
+        assertNotNull("The feature bar didn't appear in the collection", tolerates2);
+        assertThat(tolerates2, hasItem("tolerated"));
+
+        // Test setting an old style feature, should overwrite the previous data.
+        toTest.setRequireFeature(Collections.singleton("set_foo_feature"));
+        Collection<String> features3 = toTest.getRequireFeature();
+        assertThat(features3, hasSize(1));
+        assertThat(features3, hasItem("set_foo_feature"));
+
+        Map<String, Collection<String>> fwt3 = toTest.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 1, fwt3.size());
+        Collection<String> tolerates3 = fwt3.get("set_foo_feature");
+        assertNotNull("The feature set_foo_feature didn't appear in the collection", tolerates3);
+        assertThat(tolerates3, hasSize(0));
+
+        // Test setting a new style feature with tolerates info
+        Collection<String> tolerated4 = Collections.singleton("tolerated4");
+        Map<String, Collection<String>> something4 = Collections.singletonMap("feature4", tolerated4);
+        toTest.setRequireFeatureWithTolerates(something4);
+        Collection<String> features4 = toTest.getRequireFeature();
+        assertThat(features4, hasSize(1));
+        assertThat(features4, hasItem("feature4"));
+
+        Map<String, Collection<String>> fwt4 = toTest.getRequireFeatureWithTolerates();
+        assertEquals("The wrong number of features", 1, fwt4.size());
+        Collection<String> tolerates4 = fwt4.get("feature4");
+        assertNotNull("There should have been some tolerates", tolerates4);
+        assertThat(tolerates4, hasItem("tolerated4"));
+
+    }
+
+    @Test
+    public void testCopyRequireFeatureField() {
+        Asset asset = new Asset();
+        WlpInformation wlp = new WlpInformation();
+        ArrayList<String> required = new ArrayList<String>();
+        required.add("la di dah");
+        wlp.setRequireFeature(required);
+        asset.setWlpInformation(wlp);
+        EsaResourceImpl esa = new EsaResourceImpl(null, asset);
+        Collection<String> features = esa.getRequireFeature();
+        assertThat(features, hasSize(1));
+        // This should return one feature, from the requireFeature field
+        Map<String, Collection<String>> features3 = esa.getRequireFeatureWithTolerates();
+        assertEquals("There should have been 1 feature in the collection", 1, features3.size());
+        Collection<String> tolerates = features3.get("la di dah");
+        assertThat(tolerates, hasSize(0));
+        assertNull("The requireFeatureWithTolerates field should not have been set", wlp.getRequireFeatureWithTolerates());
+
+        // If a new require feature is added, the requireFeatureWithTolerates field
+        // should also be updated.
+        esa.addRequireFeature("a new feature");
+        Collection<String> features2 = esa.getRequireFeature();
+        assertThat(features2, hasSize(2));
+        assertThat(features2, hasItem("a new feature"));
+        Map<String, Collection<String>> rfwt2 = esa.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 2, rfwt2.size());
+        assertNotNull("The expected feature was not found", rfwt2.get("a new feature"));
+        assertNotNull("The expected feature was not found", rfwt2.get("la di dah"));
+    }
+
+    @Test
+    public void testCopyRequireFeatureField2() {
+        // This time testing by adding requirement via the addRequireFeatureWithTolerates method
+        Asset asset = new Asset();
+        WlpInformation wlp = new WlpInformation();
+        ArrayList<String> required = new ArrayList<String>();
+        required.add("la di dah");
+        wlp.setRequireFeature(required);
+        asset.setWlpInformation(wlp);
+        EsaResourceImpl esa = new EsaResourceImpl(null, asset);
+        Collection<String> features = esa.getRequireFeature();
+        assertThat(features, hasSize(1));
+
+        // If a new require feature is added, the requireFeatureWithTolerates field
+        // should also be updated.
+        esa.addRequireFeatureWithTolerates("a new feature", Collections.singleton("tolerated"));
+        Collection<String> features2 = esa.getRequireFeature();
+        assertThat(features2, hasSize(2));
+        assertThat(features2, hasItem("a new feature"));
+        Map<String, Collection<String>> rfwt2 = esa.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 2, rfwt2.size());
+        assertNotNull("The expected feature was not found", rfwt2.get("la di dah"));
+        Collection<String> tolerates2 = rfwt2.get("a new feature");
+        assertThat(tolerates2, hasItem("tolerated"));
+    }
+
+    @Test
+    public void testOverwritePreviousInfo() {
+        // test that if you make a second call to addReqireFeatureWithTolerates, where
+        // the second call uses the same feature name as the first, then the first entry
+        // will be overwritten, even if the tolerates info is different
+
+        EsaResourceImpl toTest = new EsaResourceImpl(null);
+        toTest.addRequireFeatureWithTolerates("feature1", Collections.singleton("tolerate1"));
+
+        // Add the same feature again, check that it overwrites
+        toTest.addRequireFeatureWithTolerates("feature1", Collections.singleton("tolerate1"));
+        Map<String, Collection<String>> rfwt = toTest.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 1, rfwt.size());
+        assertThat(rfwt, Matchers.hasEntry("feature1", (Collection<String>) Collections.singleton("tolerate1")));
+        Collection<String> rf = toTest.getRequireFeature();
+        assertThat(rf, hasSize(1));
+        assertThat(rf, hasItem("feature1"));
+
+        // Add the same feature with different tolerates info, check that it overwrites
+        toTest.addRequireFeatureWithTolerates("feature1", Collections.singleton("tolerate2"));
+        rfwt = toTest.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 1, rfwt.size());
+        assertThat(rfwt, Matchers.hasEntry("feature1", (Collection<String>) Collections.singleton("tolerate2")));
+        rf = toTest.getRequireFeature();
+        assertThat(rf, hasSize(1));
+        assertThat(rf, hasItem("feature1"));
+
+        // Add the same feature but using addRequireFeature instead
+        // This has no tolerates info, and that should cause it to overwrite the old entry
+        toTest.addRequireFeature("feature1");
+        rfwt = toTest.getRequireFeatureWithTolerates();
+        assertEquals("Wrong number of features", 1, rfwt.size());
+        assertThat(rfwt, Matchers.hasEntry("feature1", (Collection<String>) Collections.<String> emptySet()));
+        rf = toTest.getRequireFeature();
+        assertThat(rf, hasSize(1));
+        assertThat(rf, hasItem("feature1"));
+
+    }
+
+}

--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/model/test/AssetTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/model/test/AssetTest.java
@@ -215,7 +215,8 @@ public class AssetTest {
             _target = target;
         }
 
-        private void check(String name, boolean copied) throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        private void check(String name,
+                           boolean copied) throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
             Method m = Asset.class.getDeclaredMethod("get" + name, (Class[]) null);
             Object found = m.invoke(_target);
             Object expected = copied ? m.invoke(_source) : null;
@@ -406,10 +407,8 @@ public class AssetTest {
      * --------------------------------------------------------------------------
      */
 
-    private void checkJSON(Class<?> cls, Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException, InstantiationException, SecurityException,
-                    NoSuchMethodException {
+    private void checkJSON(Class<?> cls, Method setter, Object left,
+                           Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException, InstantiationException, SecurityException, NoSuchMethodException {
         Constructor<?> c = cls.getConstructor();
         Object JSON = c.newInstance();
         setter.invoke(left, JSON);
@@ -420,8 +419,7 @@ public class AssetTest {
     }
 
     private void checkPrimitive(Class<?> cls, Method setter, Object left,
-                                Object right) throws IllegalArgumentException,
-                    IllegalAccessException, InvocationTargetException {
+                                Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         String name = cls.getName();
         if ("long".equals(name)) {
             setter.invoke(left, 456);
@@ -444,14 +442,11 @@ public class AssetTest {
             setter.invoke(right, true);
             assertEquals(left, right);
         } else {
-            throw new IllegalArgumentException(
-                            "No code to handle primitive type " + name);
+            throw new IllegalArgumentException("No code to handle primitive type " + name);
         }
     }
 
-    private void checkEnum(Class<?> cls, Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException {
+    private void checkEnum(Class<?> cls, Method setter, Object left, Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         Object[] enumValues = cls.getEnumConstants();
         Object prevValue = null;
         for (Object aValue : enumValues) {
@@ -468,8 +463,7 @@ public class AssetTest {
         }
     }
 
-    private void checkFilterVersion(Method setter, Object left, Object right)
-                    throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private void checkFilterVersion(Method setter, Object left, Object right) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         FilterVersion fv1 = new FilterVersion();
         FilterVersion fv2 = new FilterVersion();
         fv1.setLabel("Fred");
@@ -482,8 +476,7 @@ public class AssetTest {
         assertEquals(left, right);
     }
 
-    private void checkLocale(Method setter, Object left, Object right)
-                    throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private void checkLocale(Method setter, Object left, Object right) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         setter.invoke(left, Locale.ENGLISH);
         assertNotEquals(left, right);
         setter.invoke(right, Locale.FRANCE);
@@ -492,8 +485,7 @@ public class AssetTest {
         assertEquals(left, right);
     }
 
-    private void checkImageDetails(Method setter, Object left, Object right)
-                    throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private void checkImageDetails(Method setter, Object left, Object right) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         // both should be null, and hence equal
         assertEquals(left, right);
         ImageDetails image1 = new ImageDetails();
@@ -514,9 +506,7 @@ public class AssetTest {
         assertEquals(left, right);
     }
 
-    private void checkString(Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException {
+    private void checkString(Method setter, Object left, Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         setter.invoke(right, (Object) null);
         setter.invoke(left, "test");
         assertNotEquals(left, right);
@@ -526,9 +516,7 @@ public class AssetTest {
         assertEquals(left, right);
     }
 
-    private void checkCollectionOfString(Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException {
+    private void checkCollectionOfString(Method setter, Object left, Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         HashSet<String> leftSet = new HashSet<String>();
         leftSet.add("Test");
         setter.invoke(left, leftSet);
@@ -540,9 +528,7 @@ public class AssetTest {
         assertEquals(left, right);
     }
 
-    private void checkCollectionOfObjects(Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException {
+    private void checkCollectionOfObjects(Method setter, Object left, Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         HashSet<Object> leftSet = new HashSet<Object>();
         leftSet.add("test data");
         setter.invoke(left, leftSet);
@@ -556,8 +542,7 @@ public class AssetTest {
     }
 
     private void checkListOfObjects(Method setter, Object left,
-                                    Object right) throws IllegalArgumentException,
-                    IllegalAccessException, InvocationTargetException {
+                                    Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         ArrayList<Object> leftSet = new ArrayList<Object>();
         ArrayList<Object> rightSet = new ArrayList<Object>();
         // Have to special case setAttachments as it does more than
@@ -583,9 +568,7 @@ public class AssetTest {
     }
 
     @SuppressWarnings("deprecation")
-    private void checkDate(Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException {
+    private void checkDate(Method setter, Object left, Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         Date leftDate = new Date();
         leftDate.setYear(2001);
         setter.invoke(left, leftDate);
@@ -597,9 +580,7 @@ public class AssetTest {
         assertEquals(left, right);
     }
 
-    private void checkCalendar(Method setter, Object left, Object right)
-                    throws IllegalArgumentException, IllegalAccessException,
-                    InvocationTargetException {
+    private void checkCalendar(Method setter, Object left, Object right) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
         Calendar leftDate = Calendar.getInstance();
         leftDate.set(2001, 6, 12);
         setter.invoke(left, leftDate);

--- a/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/model/test/AssetTest.java
+++ b/client-lib-tests/src/test/java/com/ibm/ws/repository/transport/model/test/AssetTest.java
@@ -55,6 +55,7 @@ import com.ibm.ws.repository.transport.model.FilterVersion;
 import com.ibm.ws.repository.transport.model.ImageDetails;
 import com.ibm.ws.repository.transport.model.Link;
 import com.ibm.ws.repository.transport.model.Provider;
+import com.ibm.ws.repository.transport.model.RequireFeatureWithTolerates;
 import com.ibm.ws.repository.transport.model.Reviewed;
 import com.ibm.ws.repository.transport.model.SalesContact;
 import com.ibm.ws.repository.transport.model.StateUpdateAction;
@@ -129,6 +130,11 @@ public class AssetTest {
     @Test
     public void testAttachmentInfoEquals() throws Throwable {
         checkEqualsOnClass(new AttachmentInfo(), new AttachmentInfo());
+    }
+
+    @Test
+    public void testRequireFeatureWithTolerates() throws Throwable {
+        checkEqualsOnClass(new RequireFeatureWithTolerates(), new RequireFeatureWithTolerates());
     }
 
     /**

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/EsaResource.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/EsaResource.java
@@ -16,6 +16,7 @@
 package com.ibm.ws.repository.resources;
 
 import java.util.Collection;
+import java.util.Map;
 
 import com.ibm.ws.repository.common.enums.InstallPolicy;
 import com.ibm.ws.repository.common.enums.Visibility;
@@ -44,9 +45,22 @@ public interface EsaResource extends RepositoryResource, ApplicableToProduct {
     /**
      * Gets the list of required features for this feature
      *
+     * @deprecated Should use {@link #getRequireFeatureWithTolerates()} instead
+     *
      * @return The list of required features for this feature, or null if no features are required
      */
+    @Deprecated
     public Collection<String> getRequireFeature();
+
+    /**
+     * Get the required features for this feature. Returns a map of
+     * 'required feature + version' -> 'other tolerated versions (if any)'
+     * The collection of tolerated versions will be empty if
+     * 1. There are no other tolerated versions
+     * 2. No tolerates information is available in the repository.
+     * Returns null if there are no required features.
+     */
+    public Map<String, Collection<String>> getRequireFeatureWithTolerates();
 
     /**
      * Gets the short name for this feature, as defined by the IBM-ShortName header

--- a/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/EsaResourceWritable.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/resources/writeable/EsaResourceWritable.java
@@ -16,6 +16,7 @@
 package com.ibm.ws.repository.resources.writeable;
 
 import java.util.Collection;
+import java.util.Map;
 
 import com.ibm.ws.repository.common.enums.InstallPolicy;
 import com.ibm.ws.repository.common.enums.Visibility;
@@ -23,49 +24,69 @@ import com.ibm.ws.repository.resources.EsaResource;
 
 /**
  * Represents a Feature Resource which may be uploaded to a repository.
- * 
+ *
  * @see RepositoryResourceWritable
  */
 public interface EsaResourceWritable extends WebDisplayable, ApplicableToProductWritable, EsaResource, RepositoryResourceWritable {
 
     /**
      * Set the provide feature field for this feature
-     * 
+     *
      * @param feature The name this feature should use.
      */
     public void setProvideFeature(String feature);
 
     /**
      * Add the supplied feature to the list of required features
-     * 
+     *
      * @param requiredFeatureSymbolicName The symbolic name of the feature to add
+     * @deprecated See {@link #addRequireFeatureWithTolerates(String, Collection)}.
      */
+    @Deprecated
     public void addRequireFeature(String requiredFeatureSymbolicName);
 
     /**
+     * Sets the list of required features to the supplied list of features
+     *
+     * @param feats The list of symbolic names of features
+     * @deprecated See {@link #setRequireFeatureWithTolerates(Map)}
+     */
+    @Deprecated
+    public void setRequireFeature(Collection<String> feats);
+
+    /**
+     * Sets the list of required features along with the tolerates information
+     * for those features.
+     *
+     * @param features
+     */
+    public void setRequireFeatureWithTolerates(Map<String, Collection<String>> features);
+
+    /**
+     * Add the supplied feature and tolerates info to the list of required features
+     *
+     * @param feature
+     * @param tolerates
+     */
+    public void addRequireFeatureWithTolerates(String feature, Collection<String> tolerates);
+
+    /**
      * Add the supplied fix to the list of required fixes
-     * 
+     *
      * @param fix The ID of the fix to add
      */
     public void addRequireFix(String fix);
 
     /**
-     * Sets the list of required features to the supplied list of features
-     * 
-     * @param feats The list of symbolic names of features
-     */
-    public void setRequireFeature(Collection<String> feats);
-
-    /**
      * Adds the supplied feature to the list of features which supersede this feature
-     * 
+     *
      * @param feature the symbolic name of the feature to add
      */
     public void addSupersededBy(String feature);
 
     /**
      * Gets the collection of features which supersede this feature
-     * 
+     *
      * @return a collection of symbolic names of features which supersede this feature
      */
     public Collection<String> getSupersededBy();
@@ -78,35 +99,35 @@ public interface EsaResourceWritable extends WebDisplayable, ApplicableToProduct
      * If a server config is changed to use applicationSecurity-2.0 instead of applicationSecurity-1.0, the server admin may also need to add servlet-3.0 if it was not explicitly
      * required before and applications
      * depend on it.
-     * 
+     *
      * @param feature the symbolic name of the feature to add
      */
     public void addSupersededByOptional(String feature);
 
     /**
      * Gets the list of features which may also be required by an application if this feature is replaced by the features which supersede it.
-     * 
+     *
      * @return collection of symbolic names of features which may be required if this feature is replaced by the features which supersede it.
      */
     public Collection<String> getSupersededByOptional();
 
     /**
      * Set the Visibility to the supplied {@link Visibility}
-     * 
+     *
      * @param vis The {@link Visibility} to use for this feature
      */
     public void setVisibility(Visibility vis);
 
     /**
      * Sets the ibm short name to use for this feature
-     * 
+     *
      * @param shortName The ibm short name to use
      */
     public void setShortName(String shortName);
 
     /**
      * Sets the ibmProvisionCapability field.
-     * 
+     *
      * @param ibmProvisionCapability
      *            The new ibmProvisionCapability to be used
      */
@@ -114,10 +135,10 @@ public interface EsaResourceWritable extends WebDisplayable, ApplicableToProduct
 
     /**
      * Sets the install policy for the feature
-     * 
+     *
      * An install policy of {@link InstallPolicy#WHEN_SATISFIED} should only be used if {@link #getIbmProvisionCapability()} returns a non-<code>null</code> value. This indicates
      * that the feature should be automatically installed if all of its provision capability requirements are met.
-     * 
+     *
      * @param policy the new value for installPolicy
      */
     public void setInstallPolicy(InstallPolicy policy);
@@ -125,7 +146,7 @@ public interface EsaResourceWritable extends WebDisplayable, ApplicableToProduct
     /**
      * Specify the minimum/maximum Java version needed by this ESA, and the Require-Capability headers from each contained bundle which have led to the requirement. All fields are
      * allowed to be null.
-     * 
+     *
      * @param minimum an OSGI version string representing the minimum Java version required.
      * @param maximum an OSGI version string representing the minimum Java version required.
      * @param displayMinimum An alternative representation of the minimum version for display purposes

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/model/RequireFeatureWithTolerates.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/model/RequireFeatureWithTolerates.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2017 IBM Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+package com.ibm.ws.repository.transport.model;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class RequireFeatureWithTolerates {
+
+    private String feature;
+    private Collection<String> tolerates;
+
+    public String getFeature() {
+        return this.feature;
+    }
+
+    public void setFeature(String feature) {
+        this.feature = feature;
+    }
+
+    public Collection<String> getTolerates() {
+        return this.tolerates;
+    }
+
+    public void setTolerates(Collection<String> tolerates) {
+        this.tolerates = tolerates;
+    }
+
+    public void addTolerates(String tolerate) {
+        if (this.tolerates == null) {
+            this.tolerates = new HashSet<String>();
+        }
+        tolerates.add(tolerate);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((feature == null) ? 0 : feature.hashCode());
+        result = prime * result + ((tolerates == null) ? 0 : tolerates.hashCode());
+        return result;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RequireFeatureWithTolerates other = (RequireFeatureWithTolerates) obj;
+        if (feature == null) {
+            if (other.feature != null)
+                return false;
+        } else if (!feature.equals(other.feature))
+            return false;
+
+        if (tolerates == null) {
+            if (other.tolerates != null)
+                return false;
+        } else if (!tolerates.equals(other.tolerates))
+            return false;
+        return true;
+    }
+
+}

--- a/client-lib/src/main/java/com/ibm/ws/repository/transport/model/WlpInformation.java
+++ b/client-lib/src/main/java/com/ibm/ws/repository/transport/model/WlpInformation.java
@@ -70,6 +70,7 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
     private String mainAttachmentSHA256;
     private String genericRequirements;
     private String packagedJava;
+    private Collection<RequireFeatureWithTolerates> requireFeatureWithTolerates;
 
     public String getFeaturedWeight() {
         return featuredWeight;
@@ -106,6 +107,21 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
             this.requireFeature = new HashSet<String>();
         }
         this.requireFeature.add(requireFeature);
+    }
+
+    public Collection<RequireFeatureWithTolerates> getRequireFeatureWithTolerates() {
+        return requireFeatureWithTolerates;
+    }
+
+    public void setRequireFeatureWithTolerates(Collection<RequireFeatureWithTolerates> requiredFeaturesWithTolerates) {
+        this.requireFeatureWithTolerates = requiredFeaturesWithTolerates;
+    }
+
+    public void addRequireFeatureWithTolerates(RequireFeatureWithTolerates feature) {
+        if (this.requireFeatureWithTolerates == null) {
+            this.requireFeatureWithTolerates = new HashSet<RequireFeatureWithTolerates>();
+        }
+        this.requireFeatureWithTolerates.add(feature);
     }
 
     public ResourceTypeLabel getTypeLabel() {
@@ -685,6 +701,14 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
             return false;
         }
 
+        if (requireFeatureWithTolerates == null) {
+            if (other.requireFeatureWithTolerates != null) {
+                return false;
+            }
+        } else if (!requireFeatureWithTolerates.equals(other.requireFeatureWithTolerates)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -692,8 +716,7 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
     public void validate(String version) throws IllegalStateException, BadVersionException {
         float v = Float.valueOf(version);
         if (v < MIN_VERSION || v >= MAX_VERSION) {
-            throw new BadVersionException(Float.toString(MIN_VERSION),
-                            Float.toString(MAX_VERSION), version);
+            throw new BadVersionException(Float.toString(MIN_VERSION), Float.toString(MAX_VERSION), version);
         }
     }
 


### PR DESCRIPTION
Currently, the repository metadata for an asset doesn't include the data from the ibm.tolerates field in the feature manifest (This field is documented in the "Liberty feature manifest files" section of the Liberty knowledge centre). The tolerates info should be in the asset metadata to allow better feature resolution