### PR TITLE
Bump prereq versions in preparation for 2.0.3 release:

### DIFF
--- a/LARS-2.0.3_versions.gradle
+++ b/LARS-2.0.3_versions.gradle
@@ -1,0 +1,26 @@
+/*
+ * The purpose of this file is to provide fixed versions of some
+ * these version run the gradle build with:
+ * 
+ *   -PversionFile=LARS-2.0.2_versions.gradle
+ */
+
+ext {
+	// Packaged runtime dependencies
+	// Fixed versions for the LARS 2.0 release
+	aries_util_version = "1.1.3"
+	osgi_core_version = "6.0.0"
+	jackson_version="2.10.2"
+	javax_json_version="1.1.4"
+	glassfish_json_version="1.1.4"
+	mongodb_java_version="3.12.1"
+
+	// Test/compile time only dependencies
+	// Fixed at 1.44 because jmockit frequently make breaking API changes
+        jmockit_version="1.44"
+	hamcrest_version="1.+"
+	junit_version="4.+"
+	httpclient_version="4.+"
+	httpmime_version="4.+"
+	wlp_ant_tasks_version="1.+"
+}

--- a/LARS_versions.gradle
+++ b/LARS_versions.gradle
@@ -2,17 +2,17 @@ ext {
 	// Packaged runtime dependencies
 	aries_util_version = "1.1.+"
 	osgi_core_version = "6.0.+"
-	jackson_version="2.9.+"
-	javax_json_version="1.0"
-	glassfish_json_version="1.0.+"
-	mongodb_java_version="3.11.+"
+	jackson_version="2.10.+"
+	javax_json_version="1.1.+"
+	glassfish_json_version="1.1.+"
+	mongodb_java_version="3.12.+"
 
 	// Test/compile time only dependencies
 	// Fixed at 1.44 because jmockit frequently make breaking API changes
 	jmockit_version="1.44"
 	hamcrest_version="1.+"
 	junit_version="4.+"
-	httpclient_version="4.4.+"
-	httpmime_version="4.4.+"
+	httpclient_version="4.+"
+	httpmime_version="4.+"
 	wlp_ant_tasks_version="1.+"
 }

--- a/doc/PREREQS.md
+++ b/doc/PREREQS.md
@@ -1,6 +1,6 @@
 ## In order to run LARS you need the following prerequisites
 
-* [MongoDB server](https://www.mongodb.com/download-center/community) compatible with [Java Driver v3.11](https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#java-driver-compatibility)
+* [MongoDB server](https://www.mongodb.com/download-center/community) compatible with [Java Driver v3.12](https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#java-driver-compatibility)
 * [WAS Liberty Profile 19.0.0.9](https://developer.ibm.com/wasdev/downloads/#asset/runtimes-wlp-kernel) or newer
 * A Java 8 JDK
 


### PR DESCRIPTION
jackson 2.9.9 to 2.10.2
javax.json and glassfish.json from 1.0.x to 1.1.4
mongodb-java-client 3.11.1 to 3.12.1
Test dependencies:
httpclient and httpmime from 4.4.x to 4.x (currently 4.5.x)