### PR TITLE
Fix Test and ignore find bugs false positive

### DIFF
--- a/client-lib-tests/src/fat/java/com/ibm/ws/repository/test/RepositoryUtilsTest.java
+++ b/client-lib-tests/src/fat/java/com/ibm/ws/repository/test/RepositoryUtilsTest.java
@@ -82,12 +82,14 @@ public class RepositoryUtilsTest {
     }
 
     @Test
-    public void testInvalidRepositoryThrowsException() throws IOException, RequestFailureException {
+    public void testInvalidRepositoryThrowsException() {
         RestRepositoryConnection invalidLoginInfo = new RestRepositoryConnection("I", "don't", "exist", "http://dont252qmadjf842sgs7842d.hu43634existsaosd.com");
         try {
             invalidLoginInfo.checkRepositoryStatus();
             fail("Should not have been able to reach here, repository status should have thrown an exception");
         } catch (IOException io) {
+            // expected
+        } catch (RequestFailureException rfe) {
             // expected
         }
     }

--- a/client-lib/findbugs.exclude.xml
+++ b/client-lib/findbugs.exclude.xml
@@ -32,5 +32,12 @@
         <Class name="com.ibm.ws.repository.strategies.writeable.AddThenDeleteStrategy" />
         <Method name="uploadAsset" />
     </Match>
+    
+    <!-- Findbugs is reporting a public field is not set when it has been set in superclass -->
+    <Match>
+        <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD" />
+        <Class name="com.ibm.ws.repository.transport.client.AbstractFileClient" />
+    </Match>
+    
 
 </FindBugsFilter>


### PR DESCRIPTION
When an ISP provides it's own page for when a URL can not be found (which would usually return a 404), it instead returns a 200, the test was not correctly expected the RequestFailureException when no assets could be found.

Also ignore the false positive that implies a field was not being set when it was set in the superclass.